### PR TITLE
Fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# ubuntu / focal (20.04-LTS)
-FROM ubuntu:focal
+# ubuntu / impish (21.10)
+FROM ubuntu:impish
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,10 +10,6 @@ copier le dépot source
 
     git clone https://github.com/dbarzin/mercator
 
-recopier le fichier docker-compose.yml.tmp afin d'apporter vos propres adaptations
-
-    cp docker-compose.yml.tmpl docker-compose.yml
-
 Aller dans le répertoire mercator
 
     cd mercator/docker


### PR DESCRIPTION
Ubuntu 20.04 is packaged with PHP7 but composer needs PHP8.
Changed Docker file to Ubuntu 21.10.