### PR TITLE
Entity types, types may be used to filter displayed elements on ecosystem view.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ storage/*.key
 storage/logs
 stubs/
 vendor/
+*.xlsx
+tests/Browser/console/*.log

--- a/INSTALL.fr.md
+++ b/INSTALL.fr.md
@@ -7,7 +7,7 @@
 - Disque : 50G
 - VCPU 2
 
-## Installation 
+## Installation 1
 
 Mettre à jour la distribution linux
 
@@ -77,8 +77,10 @@ Mettre les paramètre de connexion à la base de données :
 
     ## .env file
     DB_CONNECTION=mysql
+    # DB_CONNECTION=pgsql
     DB_HOST=127.0.0.1
     DB_PORT=3306
+    # Commenter DB_PORT pour pgsql
     DB_DATABASE=mercator
     DB_USERNAME=mercator_user
     DB_PASSWORD=s3cr3t
@@ -103,6 +105,10 @@ Vider la cache
 Pour importer la base de données de test (facultatif)
 
     sudo mysql mercator < mercator_data.sql
+
+ou (Postgres):
+
+   psql mercator < pg_mercator_data.sql
 
 Démarrer l'application avec php
 
@@ -235,6 +241,10 @@ Avant de mettre à jour l'application prenez un backup de la base de données et
 
     mysqldump mercator > mercator_backup.sql
 
+ou (Postgres)
+
+   pg_dump mercator > mercator_backup.sql
+
 Récupérer les sources de GIT
 
     cd /var/www/mercator
@@ -293,6 +303,16 @@ Sauvegarder la base de données
         --no-create-info \
         > backup_mercator_data.sql
 
+ou (Postgres) :
+
+   pg_dump --exclude-table=users \
+   --exclude-table=roles \
+   --exclude-table=permissions \
+   --exclude-table=permission_role \
+   --exclude-table=role_user  \
+   --exclude-table=migrations  \
+   mercator > backup_mercator_data.sql
+
 Then backup database users
 
     sudo mysqldump mercator \
@@ -300,13 +320,27 @@ Then backup database users
         --add-drop-table \
         > backup_mercator_users.sql
 
+ou (Postgres):
+
+   pg_dump --clean \
+   -t users -t roles -t role_user \
+   > backup_mercator_users.sql
+   
 Supprimer la base de données de Mercator
 
     sudo mysql -e "drop database mercator;"
 
+ou (Postgres)
+
+   dropdb mercator
+   
 Créer une nouvelle base de données
 
     sudo mysql -e "CREATE DATABASE mercator CHARACTER SET utf8 COLLATE utf8_general_ci;"
+
+ou (Postgres)
+
+   createdb mercator
 
 Exécuter les migrations
 
@@ -320,8 +354,16 @@ Restaurer les données
 
     sudo mysql mercator < backup_mercator_data.sql
 
+ou (Postgres)
+
+   psql mercator < backup_mercator_data.sql
+
 Restaurer les utilisateurs
 
     sudo mysql mercator < backup_mercator_users.sql
+
+ou (Postgres)
+
+   psql mercator < backup_mercator_users.sql
 
 Tous les problèmes de migration devraient être résolus.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,8 +82,10 @@ Put the connection parameters to the database :
 
     ## .env file
     DB_CONNECTION=mysql
+    # DB_CONNECTION=pgsql
     DB_HOST=127.0.0.1
     DB_PORT=3306
+    # Comment DB_PORT for pgsql
     DB_DATABASE=mercator
     DB_USERNAME=mercator_user
     DB_PASSWORD=s3cr3t
@@ -109,6 +111,10 @@ To import the test database (optional)
 
     sudo mysql mercator < mercator_data.sql
 
+or (Postgres)
+
+   psql mercator < pg_mercator_data.sql
+   
 Start the application with php
 
     php artisan serve
@@ -224,6 +230,10 @@ Before updating the application take a backup of the database and the project.
 
     mysqldump mercator > mercator_backup.sql
 
+or (Postgres)
+
+   pg_dump mercator > mercator_backup.sql
+
 Get the sources from GIT
 
     cd /var/www/mercator
@@ -287,6 +297,16 @@ Backup the database
         --ignore-table=mercator.migrations \
         > backup_mercator_data.sql
 
+or (Postgres)
+
+   pg_dump --exclude-table=users \
+   --exclude-table=roles \
+   --exclude-table=permissions \
+   --exclude-table=permission_role \
+   --exclude-table=role_user  \
+   --exclude-table=migrations  \
+   mercator > backup_mercator_data.sql
+
 Then backup database users
 
     mysqldump mercator \
@@ -294,6 +314,12 @@ Then backup database users
         --tables users roles role_user
         --add-drop-table \
         > backup_mercator_users.sql
+
+or (Postgres):
+
+   pg_dump --clean \
+   -t users -t roles -t role_user \
+   > backup_mercator_users.sql
 
 Delete the Mercator database
 
@@ -315,9 +341,17 @@ Restore the data and fix errors
 
     mysql mercator < backup_mercator_data.sql
 
+or (Postgres)
+
+   psql mercator < backup_mercator_data.sql
+
 Restore users
 
     mysql mercator < backup_mercator_users.sql
+
+or (Postgres)
+
+   psql mercator < backup_mercator_users.sql
 
 All migration issues should be resolved.
 

--- a/app/Entity.php
+++ b/app/Entity.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $security_level
  * @property string|null $contact_point
  * @property string|null $description
+ * @property string|null $entity_type
  * @property boolean|false $is_external
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -61,6 +62,7 @@ class Entity extends Model
         'description',
         'security_level',
         'contact_point',
+        'entity_type',
     ];
 
     protected $dates = [
@@ -75,6 +77,7 @@ class Entity extends Model
         'security_level',
         'contact_point',
         'is_external',
+        'entity_type',
         'created_at',
         'updated_at',
         'deleted_at',

--- a/app/Http/Controllers/Admin/CartographyController.php
+++ b/app/Http/Controllers/Admin/CartographyController.php
@@ -181,6 +181,7 @@ class CartographyController extends Controller
                 $this->addHTMLRow($table, trans('cruds.entity.fields.security_level'), $entity->security_level);
                 $this->addHTMLRow($table, trans('cruds.entity.fields.contact_point'), $entity->contact_point);
                 $this->addHTMLRow($table, trans('cruds.entity.fields.is_external'), $entity->is_external);
+                $this->addHTMLRow($table, trans('cruds.entity.fields.entity_type'), $entity->entity_type);
 
                 // Relations
                 $textRun = $this->addTextRunRow($table, trans('cruds.entity.fields.relations'));

--- a/app/Http/Controllers/Admin/EntityController.php
+++ b/app/Http/Controllers/Admin/EntityController.php
@@ -32,8 +32,10 @@ class EntityController extends Controller
         $processes = Process::orderBy('identifiant')->pluck('identifiant', 'id');
         $applications = MApplication::orderBy('name')->pluck('name', 'id');
         $databases = Database::orderBy('name')->pluck('name', 'id');
-
-        return view('admin.entities.create', compact('processes', 'applications', 'databases'));
+        $entityTypes= Entity::select('entity_type')
+                    ->where('entity_type', '<>', null)->distinct()
+                    ->orderBy('entity_type')->pluck('entity_type');
+        return view('admin.entities.create', compact('processes', 'entityTypes','applications', 'databases'));
     }
 
     public function store(StoreEntityRequest $request)
@@ -66,14 +68,15 @@ class EntityController extends Controller
     public function edit(Entity $entity)
     {
         abort_if(Gate::denies('entity_edit'), Response::HTTP_FORBIDDEN, '403 Forbidden');
-
         $processes = Process::orderBy('identifiant')->pluck('identifiant', 'id');
         $applications = MApplication::orderBy('name')->pluck('name', 'id');
         $databases = Database::orderBy('name')->pluck('name', 'id');
-
+        $entityTypes= Entity::select('entity_type')
+                    ->where('entity_type', '<>', null)->distinct()
+                    ->orderBy('entity_type')->pluck('entity_type');
         $entity->load('entitiesProcesses', 'applications', 'databases');
 
-        return view('admin.entities.edit', compact('entity', 'processes', 'applications', 'databases'));
+        return view('admin.entities.edit', compact('entity', 'entityTypes', 'processes', 'applications', 'databases'));
     }
 
     public function update(UpdateEntityRequest $request, Entity $entity)

--- a/app/Http/Controllers/Admin/ReportController.php
+++ b/app/Http/Controllers/Admin/ReportController.php
@@ -61,32 +61,62 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class ReportController extends Controller
 {
+    const ALLOWED_PERIMETERS  = ['All','Internes','Externes'];
+    const SANITIZED_PERIMETER = 'All';
+
     public function ecosystem(Request $request)
     {
-        if (($request->perimeter === null) || ($request->perimeter === 'all')) {
-            $request->session()->put('perimeter','all');
-            $entities = Entity::All()->sortBy('name');
-            $relations = Relation::All()->sortBy('name');
-            return view('admin/reports/ecosystem')
-                ->with('entities', $entities)
-            ->with('relations', $relations);
-        } else {
-            $perimeter = $request->perimeter;
-            $entities = Entity::All()->sortBy('name')->filter(function ($item)  use ($perimeter){
-                if ($perimeter == 'Externes' ) {
-                    return $item->is_external == 'true';
-                } else {
-                    return  !($item->is_external == 'true');
-                }
-            });
-            $relations = Relation::All()->sortBy('name') ->filter(function ($item)  use ($entities){
-                return $entities->contains($item->source_id) && $entities->contains($item->destination_id);
-            });
-            $request->session()->put('perimeter', $request->perimeter);
-            return view('admin/reports/ecosystem')
-                ->with('entities',  $entities)
-                ->with('relations', $relations);
+        $perimeter = in_array($request->perimeter, $this::ALLOWED_PERIMETERS) ? 
+                   $request->perimeter : $this::SANITIZED_PERIMETER;
+        $typefilter = $request->entity_type ??= 'All';
+        
+        $entitiesGroups  = Entity::All()->groupBy('entity_type');
+        $entities = collect([]);
+        $entityTypes =  collect([]);
+        $isTypeExists = false; /* sanitize entity_type: si type inconnu pas d'entités*/
+        foreach($entitiesGroups as $entity_type => $entOfGroup)
+        {
+            $entities = $entities->concat($entOfGroup);
+            if ($entity_type != null) {
+                $isTypeExists = $isTypeExists ||  ($entity_type ==  $typefilter);
+                $entityTypes->push($entity_type);
+            }
+        }
+
+        $has_filter = false;
+        if ($typefilter != 'All'  ) {
+            $has_filter = true;
+            $entities = $isTypeExists  ? $entitiesGroups[$typefilter] : collect([]);                  
+        }
+        
+        if ($perimeter != 'All') {
+            $has_filter = true;
+            $entities = $entities
+                      ->filter(function ($item)  use ($perimeter){
+                          return ('Externes' == $perimeter) ?
+                                             $item->is_external : (! $item->is_external);
+                      });
+        }
+        
+        $relations = Relation::All()->sortBy('name');
+        if ($has_filter){
+            /**
+             * Le "group by" semble résoudre les entités on doit travailler avec les ids ..
+             */
+            $ids = $entities->map(function ($item) {return $item->id;});
+            $relations = $relations
+                       ->filter(function ($item)  use ($ids){
+                           return $ids->contains($item->source_id) &&
+                               $ids->contains($item->destination_id);
+                       });
 	    }
+        
+        $request->session()->put('perimeter', $perimeter);
+        $request->session()->put('entity_type', $typefilter);
+        return view('admin/reports/ecosystem')
+            ->with('entityTypes', $entityTypes)
+            ->with('entities', $entities)
+            ->with('relations', $relations);
     }
 
     public function informationSystem(Request $request)

--- a/database/migrations/2022_05_21_103208_add_type_property_to_entities.php
+++ b/database/migrations/2022_05_21_103208_add_type_property_to_entities.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class addTypePropertyToEntities extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('entities', function (Blueprint $table) {
+            $table->string('entity_type')->nullable()->index('type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('entities', function (Blueprint $table) {
+            $table->dropColumn('entity_type');
+        });
+    }
+}

--- a/mercator_data.sql
+++ b/mercator_data.sql
@@ -2,744 +2,816 @@
 --
 -- Host: localhost    Database: mercator
 -- ------------------------------------------------------
--- Server version	8.0.29-0ubuntu0.21.10.2
+-- Server version	8.0.29-0ubuntu0.20.04.3
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO,ANSI' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
--- Dumping data for table "activities"
+-- Dumping data for table `activities`
 --
 
-LOCK TABLES "activities" WRITE;
-/*!40000 ALTER TABLE "activities" DISABLE KEYS */;
-INSERT INTO "activities" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Activité 1','<p>Description de l\'activité 1</p>','2020-06-10 13:20:42','2020-06-10 13:20:42',NULL),(2,'Activité 2','<p>Description de l\'activité de test</p>','2020-06-10 15:44:26','2020-06-13 04:03:26',NULL),(3,'Activité 3','<p>Description de l\'activité 3</p>','2020-06-13 04:57:08','2020-06-13 04:57:08',NULL),(4,'Activité 4','<p>Description de l\'acivité 4</p>','2020-06-13 04:57:24','2020-06-13 04:57:24',NULL),(5,'Activité principale','<p>Description de l\'activité principale</p>','2020-08-15 04:19:53','2020-08-15 04:19:53',NULL),(6,'AAA','test a1','2021-03-22 19:06:55','2021-03-22 19:07:00','2021-03-22 19:07:00'),(7,'AAA','test AAA','2021-03-22 19:13:43','2021-03-22 19:14:05','2021-03-22 19:14:05'),(8,'AAA','test 2 aaa','2021-03-22 19:14:16','2021-03-22 19:14:45','2021-03-22 19:14:45'),(9,'AAA1','test 3 AAA','2021-03-22 19:14:40','2021-03-22 19:19:09','2021-03-22 19:19:09'),(10,'Activité 0','<p>Description de l\'activité zéro</p>',NULL,'2021-05-15 07:40:16',NULL),(11,'test','dqqsd','2021-08-02 20:03:46','2021-09-22 10:59:48','2021-09-22 10:59:48');
-/*!40000 ALTER TABLE "activities" ENABLE KEYS */;
+LOCK TABLES `activities` WRITE;
+/*!40000 ALTER TABLE `activities` DISABLE KEYS */;
+INSERT INTO `activities` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Activité 1','<p>Description de l\'activité 1</p>','2020-06-10 13:20:42','2020-06-10 13:20:42',NULL),(2,'Activité 2','<p>Description de l\'activité de test</p>','2020-06-10 15:44:26','2020-06-13 04:03:26',NULL),(3,'Activité 3','<p>Description de l\'activité 3</p>','2020-06-13 04:57:08','2020-06-13 04:57:08',NULL),(4,'Activité 4','<p>Description de l\'acivité 4</p>','2020-06-13 04:57:24','2020-06-13 04:57:24',NULL),(5,'Activité principale','<p>Description de l\'activité principale</p>','2020-08-15 04:19:53','2020-08-15 04:19:53',NULL),(6,'AAA','test a1','2021-03-22 19:06:55','2021-03-22 19:07:00','2021-03-22 19:07:00'),(7,'AAA','test AAA','2021-03-22 19:13:43','2021-03-22 19:14:05','2021-03-22 19:14:05'),(8,'AAA','test 2 aaa','2021-03-22 19:14:16','2021-03-22 19:14:45','2021-03-22 19:14:45'),(9,'AAA1','test 3 AAA','2021-03-22 19:14:40','2021-03-22 19:19:09','2021-03-22 19:19:09'),(10,'Activité 0','<p>Description de l\'activité zéro</p>',NULL,'2021-05-15 07:40:16',NULL),(11,'test','dqqsd','2021-08-02 20:03:46','2021-09-22 10:59:48','2021-09-22 10:59:48');
+/*!40000 ALTER TABLE `activities` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "activity_operation"
+-- Dumping data for table `activity_operation`
 --
 
-LOCK TABLES "activity_operation" WRITE;
-/*!40000 ALTER TABLE "activity_operation" DISABLE KEYS */;
-INSERT INTO "activity_operation" ("activity_id", "operation_id") VALUES (2,3),(1,1),(1,2),(4,3),(3,1),(1,5),(5,1),(6,1),(10,1);
-/*!40000 ALTER TABLE "activity_operation" ENABLE KEYS */;
+LOCK TABLES `activity_operation` WRITE;
+/*!40000 ALTER TABLE `activity_operation` DISABLE KEYS */;
+INSERT INTO `activity_operation` (`activity_id`, `operation_id`) VALUES (2,3),(1,1),(1,2),(4,3),(3,1),(1,5),(5,1),(6,1),(10,1);
+/*!40000 ALTER TABLE `activity_operation` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "activity_process"
+-- Dumping data for table `activity_process`
 --
 
-LOCK TABLES "activity_process" WRITE;
-/*!40000 ALTER TABLE "activity_process" DISABLE KEYS */;
-INSERT INTO "activity_process" ("process_id", "activity_id") VALUES (1,1),(1,2),(2,3),(2,4),(3,2),(3,5),(4,5),(5,4),(6,4),(7,3),(8,4),(9,3),(1,10);
-/*!40000 ALTER TABLE "activity_process" ENABLE KEYS */;
+LOCK TABLES `activity_process` WRITE;
+/*!40000 ALTER TABLE `activity_process` DISABLE KEYS */;
+INSERT INTO `activity_process` (`process_id`, `activity_id`) VALUES (1,1),(1,2),(2,3),(2,4),(3,2),(3,5),(4,5),(5,4),(6,4),(7,3),(8,4),(9,3),(1,10);
+/*!40000 ALTER TABLE `activity_process` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "actor_operation"
+-- Dumping data for table `actor_operation`
 --
 
-LOCK TABLES "actor_operation" WRITE;
-/*!40000 ALTER TABLE "actor_operation" DISABLE KEYS */;
-INSERT INTO "actor_operation" ("operation_id", "actor_id") VALUES (2,1),(1,1),(1,4),(2,5),(3,6),(5,4);
-/*!40000 ALTER TABLE "actor_operation" ENABLE KEYS */;
+LOCK TABLES `actor_operation` WRITE;
+/*!40000 ALTER TABLE `actor_operation` DISABLE KEYS */;
+INSERT INTO `actor_operation` (`operation_id`, `actor_id`) VALUES (2,1),(1,1),(1,4),(2,5),(3,6),(5,4);
+/*!40000 ALTER TABLE `actor_operation` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "actors"
+-- Dumping data for table `actors`
 --
 
-LOCK TABLES "actors" WRITE;
-/*!40000 ALTER TABLE "actors" DISABLE KEYS */;
-INSERT INTO "actors" ("id", "name", "nature", "type", "contact", "created_at", "updated_at", "deleted_at") VALUES (1,'Jean','Personne','interne','jean@testdomain.org','2020-06-14 11:02:22','2021-05-16 17:37:49',NULL),(2,'Service 1','Groupe','interne',NULL,'2020-06-14 11:02:39','2020-06-17 14:43:42','2020-06-17 14:43:42'),(3,'Service 2','Groupe','Interne',NULL,'2020-06-14 11:02:54','2020-06-17 14:43:46','2020-06-17 14:43:46'),(4,'Pierre','Personne','interne','email : pierre@testdomain.com','2020-06-17 14:44:01','2021-05-16 17:38:19',NULL),(5,'Jacques','personne','interne','Téléphone 1234543423','2020-06-17 14:44:23','2020-06-17 14:44:23',NULL),(6,'Fournisseur 1','entité','externe','Tel : 1232 32312','2020-06-17 14:44:50','2020-06-17 14:44:50',NULL);
-/*!40000 ALTER TABLE "actors" ENABLE KEYS */;
+LOCK TABLES `actors` WRITE;
+/*!40000 ALTER TABLE `actors` DISABLE KEYS */;
+INSERT INTO `actors` (`id`, `name`, `nature`, `type`, `contact`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Jean','Personne','interne','jean@testdomain.org','2020-06-14 11:02:22','2021-05-16 17:37:49',NULL),(2,'Service 1','Groupe','interne',NULL,'2020-06-14 11:02:39','2020-06-17 14:43:42','2020-06-17 14:43:42'),(3,'Service 2','Groupe','Interne',NULL,'2020-06-14 11:02:54','2020-06-17 14:43:46','2020-06-17 14:43:46'),(4,'Pierre','Personne','interne','email : pierre@testdomain.com','2020-06-17 14:44:01','2021-05-16 17:38:19',NULL),(5,'Jacques','personne','interne','Téléphone 1234543423','2020-06-17 14:44:23','2020-06-17 14:44:23',NULL),(6,'Fournisseur 1','entité','externe','Tel : 1232 32312','2020-06-17 14:44:50','2020-06-17 14:44:50',NULL);
+/*!40000 ALTER TABLE `actors` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "annuaires"
+-- Dumping data for table `annuaires`
 --
 
-LOCK TABLES "annuaires" WRITE;
-/*!40000 ALTER TABLE "annuaires" DISABLE KEYS */;
-INSERT INTO "annuaires" ("id", "name", "description", "solution", "created_at", "updated_at", "deleted_at", "zone_admin_id") VALUES (1,'AD01','<p>Annuaire principal&nbsp;</p>','Acive Directory','2020-07-03 07:49:37','2022-03-22 19:33:39',NULL,1),(2,'Mercator','<p>Cartographie du système d\'information</p>','Logiciel développé maison','2020-07-03 10:24:48','2020-07-13 15:12:59',NULL,1);
-/*!40000 ALTER TABLE "annuaires" ENABLE KEYS */;
+LOCK TABLES `annuaires` WRITE;
+/*!40000 ALTER TABLE `annuaires` DISABLE KEYS */;
+INSERT INTO `annuaires` (`id`, `name`, `description`, `solution`, `created_at`, `updated_at`, `deleted_at`, `zone_admin_id`) VALUES (1,'AD01','<p>Annuaire principal&nbsp;</p>','Acive Directory','2020-07-03 07:49:37','2022-03-22 19:33:39',NULL,1),(2,'Mercator','<p>Cartographie du système d\'information</p>','Logiciel développé maison','2020-07-03 10:24:48','2020-07-13 15:12:59',NULL,1);
+/*!40000 ALTER TABLE `annuaires` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "application_blocks"
+-- Dumping data for table `application_blocks`
 --
 
-LOCK TABLES "application_blocks" WRITE;
-/*!40000 ALTER TABLE "application_blocks" DISABLE KEYS */;
-INSERT INTO "application_blocks" ("id", "name", "description", "responsible", "created_at", "updated_at", "deleted_at") VALUES (1,'Bloc applicatif 1','<p>Description du bloc applicatif</p>','Jean Pierre','2020-06-13 04:09:01','2020-06-13 04:09:01',NULL),(2,'Bloc applicatif 2','<p>Second bloc applicatif.</p>','Marcel pierre','2020-06-13 04:10:52','2020-06-17 16:13:33',NULL),(3,'Bloc applicatif 3','<p>Description du block applicatif 3</p>','Nestor','2020-08-29 12:00:10','2022-03-20 17:53:29',NULL);
-/*!40000 ALTER TABLE "application_blocks" ENABLE KEYS */;
+LOCK TABLES `application_blocks` WRITE;
+/*!40000 ALTER TABLE `application_blocks` DISABLE KEYS */;
+INSERT INTO `application_blocks` (`id`, `name`, `description`, `responsible`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Bloc applicatif 1','<p>Description du bloc applicatif</p>','Jean Pierre','2020-06-13 04:09:01','2020-06-13 04:09:01',NULL),(2,'Bloc applicatif 2','<p>Second bloc applicatif.</p>','Marcel pierre','2020-06-13 04:10:52','2020-06-17 16:13:33',NULL),(3,'Bloc applicatif 3','<p>Description du block applicatif 3</p>','Nestor','2020-08-29 12:00:10','2022-03-20 17:53:29',NULL);
+/*!40000 ALTER TABLE `application_blocks` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "application_module_application_service"
+-- Dumping data for table `application_module_application_service`
 --
 
-LOCK TABLES "application_module_application_service" WRITE;
-/*!40000 ALTER TABLE "application_module_application_service" DISABLE KEYS */;
-INSERT INTO "application_module_application_service" ("application_service_id", "application_module_id") VALUES (4,1),(4,2),(3,3),(2,4),(1,5),(1,6),(5,2),(5,3),(6,2),(6,3),(7,2),(7,3),(8,2),(8,3),(9,2),(9,3),(10,2),(10,3),(11,2),(11,3);
-/*!40000 ALTER TABLE "application_module_application_service" ENABLE KEYS */;
+LOCK TABLES `application_module_application_service` WRITE;
+/*!40000 ALTER TABLE `application_module_application_service` DISABLE KEYS */;
+INSERT INTO `application_module_application_service` (`application_service_id`, `application_module_id`) VALUES (4,1),(4,2),(3,3),(2,4),(1,5),(1,6),(5,2),(5,3),(6,2),(6,3),(7,2),(7,3),(8,2),(8,3),(9,2),(9,3),(10,2),(10,3),(11,2),(11,3);
+/*!40000 ALTER TABLE `application_module_application_service` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "application_modules"
+-- Dumping data for table `application_modules`
 --
 
-LOCK TABLES "application_modules" WRITE;
-/*!40000 ALTER TABLE "application_modules" DISABLE KEYS */;
-INSERT INTO "application_modules" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Module 1','<p>Description du module 1</p>','2020-06-13 09:55:34','2020-06-13 09:55:34',NULL),(2,'Module 2','<p>Description du module 2</p>','2020-06-13 09:55:45','2020-06-13 09:55:45',NULL),(3,'Module 3','<p>Description du module 3</p>','2020-06-13 09:56:00','2020-06-13 09:56:00',NULL),(4,'Module 4','<p>Description du module 4</p>','2020-06-13 09:56:10','2020-06-13 09:56:10',NULL),(5,'Module 5','<p>Description du module 5</p>','2020-06-13 09:56:20','2020-06-13 09:56:20',NULL),(6,'Module 6','<p>Description du module 6</p>','2020-06-13 09:56:32','2020-06-13 09:56:32',NULL);
-/*!40000 ALTER TABLE "application_modules" ENABLE KEYS */;
+LOCK TABLES `application_modules` WRITE;
+/*!40000 ALTER TABLE `application_modules` DISABLE KEYS */;
+INSERT INTO `application_modules` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Module 1','<p>Description du module 1</p>','2020-06-13 09:55:34','2020-06-13 09:55:34',NULL),(2,'Module 2','<p>Description du module 2</p>','2020-06-13 09:55:45','2020-06-13 09:55:45',NULL),(3,'Module 3','<p>Description du module 3</p>','2020-06-13 09:56:00','2020-06-13 09:56:00',NULL),(4,'Module 4','<p>Description du module 4</p>','2020-06-13 09:56:10','2020-06-13 09:56:10',NULL),(5,'Module 5','<p>Description du module 5</p>','2020-06-13 09:56:20','2020-06-13 09:56:20',NULL),(6,'Module 6','<p>Description du module 6</p>','2020-06-13 09:56:32','2020-06-13 09:56:32',NULL);
+/*!40000 ALTER TABLE `application_modules` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "application_service_m_application"
+-- Dumping data for table `application_service_m_application`
 --
 
-LOCK TABLES "application_service_m_application" WRITE;
-/*!40000 ALTER TABLE "application_service_m_application" DISABLE KEYS */;
-INSERT INTO "application_service_m_application" ("m_application_id", "application_service_id") VALUES (2,3),(2,4),(1,3),(15,2),(15,3),(1,1),(4,11),(4,5),(2,7),(4,7),(1,10),(16,10),(16,11),(16,5),(16,6),(16,7),(16,9),(16,1),(16,2),(16,3),(16,4),(16,8);
-/*!40000 ALTER TABLE "application_service_m_application" ENABLE KEYS */;
+LOCK TABLES `application_service_m_application` WRITE;
+/*!40000 ALTER TABLE `application_service_m_application` DISABLE KEYS */;
+INSERT INTO `application_service_m_application` (`m_application_id`, `application_service_id`) VALUES (2,3),(2,4),(1,3),(15,2),(15,3),(1,1),(4,11),(4,5),(2,7),(4,7),(1,10),(16,10),(16,11),(16,5),(16,6),(16,7),(16,9),(16,1),(16,2),(16,3),(16,4),(16,8);
+/*!40000 ALTER TABLE `application_service_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "application_services"
+-- Dumping data for table `application_services`
 --
 
-LOCK TABLES "application_services" WRITE;
-/*!40000 ALTER TABLE "application_services" DISABLE KEYS */;
-INSERT INTO "application_services" ("id", "description", "exposition", "name", "created_at", "updated_at", "deleted_at") VALUES (1,'<p>Descrition du service applicatif 1</p>','cloud','SRV-1','2020-06-13 09:35:31','2021-08-03 18:50:33',NULL),(2,'<p>Description du service 2</p>','local','Service 2','2020-06-13 09:35:48','2020-06-13 09:35:48',NULL),(3,'<p>Description du service 3</p>','local','Service 3','2020-06-13 09:36:04','2020-06-13 09:43:05',NULL),(4,'<p>Description du service 4</p>','local','Service 4','2020-06-13 09:36:17','2020-06-13 09:36:17',NULL),(5,'<p>Service applicatif 4</p>','Extranet','SRV-4','2021-08-02 14:11:43','2021-08-17 08:24:10',NULL),(6,'<p>Service applicatif 4</p>',NULL,'SRV-5','2021-08-02 14:12:19','2021-08-02 14:12:19',NULL),(7,'<p>Service applicatif 4</p>',NULL,'SRV-6','2021-08-02 14:12:56','2021-08-02 14:12:56',NULL),(8,'<p>The service 99</p>','local','SRV-99','2021-08-02 14:13:39','2021-09-07 16:53:36',NULL),(9,'<p>Service applicatif 4</p>',NULL,'SRV-9','2021-08-02 14:14:27','2021-08-02 14:14:27',NULL),(10,'<p>Service applicatif 4</p>','Extranet','SRV-10','2021-08-02 14:15:21','2021-08-17 08:24:20',NULL),(11,'<p>Service applicatif 4</p>','Extranet','SRV-11','2021-08-02 14:16:34','2021-08-17 08:24:28',NULL);
-/*!40000 ALTER TABLE "application_services" ENABLE KEYS */;
+LOCK TABLES `application_services` WRITE;
+/*!40000 ALTER TABLE `application_services` DISABLE KEYS */;
+INSERT INTO `application_services` (`id`, `description`, `exposition`, `name`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'<p>Descrition du service applicatif 1</p>','cloud','SRV-1','2020-06-13 09:35:31','2021-08-03 18:50:33',NULL),(2,'<p>Description du service 2</p>','local','Service 2','2020-06-13 09:35:48','2020-06-13 09:35:48',NULL),(3,'<p>Description du service 3</p>','local','Service 3','2020-06-13 09:36:04','2020-06-13 09:43:05',NULL),(4,'<p>Description du service 4</p>','local','Service 4','2020-06-13 09:36:17','2020-06-13 09:36:17',NULL),(5,'<p>Service applicatif 4</p>','Extranet','SRV-4','2021-08-02 14:11:43','2021-08-17 08:24:10',NULL),(6,'<p>Service applicatif 4</p>',NULL,'SRV-5','2021-08-02 14:12:19','2021-08-02 14:12:19',NULL),(7,'<p>Service applicatif 4</p>',NULL,'SRV-6','2021-08-02 14:12:56','2021-08-02 14:12:56',NULL),(8,'<p>The service 99</p>','local','SRV-99','2021-08-02 14:13:39','2021-09-07 16:53:36',NULL),(9,'<p>Service applicatif 4</p>',NULL,'SRV-9','2021-08-02 14:14:27','2021-08-02 14:14:27',NULL),(10,'<p>Service applicatif 4</p>','Extranet','SRV-10','2021-08-02 14:15:21','2021-08-17 08:24:20',NULL),(11,'<p>Service applicatif 4</p>','Extranet','SRV-11','2021-08-02 14:16:34','2021-08-17 08:24:28',NULL);
+/*!40000 ALTER TABLE `application_services` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "bay_wifi_terminal"
+-- Dumping data for table `audit_logs`
 --
 
-LOCK TABLES "bay_wifi_terminal" WRITE;
-/*!40000 ALTER TABLE "bay_wifi_terminal" DISABLE KEYS */;
-/*!40000 ALTER TABLE "bay_wifi_terminal" ENABLE KEYS */;
+LOCK TABLES `audit_logs` WRITE;
+/*!40000 ALTER TABLE `audit_logs` DISABLE KEYS */;
+INSERT INTO `audit_logs` (`id`, `description`, `subject_id`, `subject_type`, `user_id`, `properties`, `host`, `created_at`, `updated_at`) VALUES (1,'updated',18,'App\\Entity',1,'{\"id\":18,\"name\":\"Acme corp.\",\"security_level\":\"<p>None sorry...<\\/p>\",\"contact_point\":\"<p>Do not call me, I will call you back.<\\/p>\",\"description\":\"<p>Looney tunes academy<\\/p>\",\"is_external\":\"1\",\"created_at\":\"2021-09-07 20:07:16\",\"updated_at\":\"2022-05-21 02:51:30\",\"deleted_at\":null}','127.0.0.1','2022-05-21 00:51:30','2022-05-21 00:51:30'),(2,'updated',9,'App\\Entity',1,'{\"id\":9,\"name\":\"NetworkSys\",\"security_level\":\"<p>ISO 27001<\\/p>\",\"contact_point\":\"<p>support@networksys.fr<\\/p>\",\"description\":\"<p>Description de l\\u2019entit\\u00e9 NetworkSys<\\/p>\",\"is_external\":\"1\",\"created_at\":\"2020-05-21 08:25:15\",\"updated_at\":\"2022-05-21 03:42:56\",\"deleted_at\":null}','127.0.0.1','2022-05-21 01:42:56','2022-05-21 01:42:56'),(3,'updated',1,'App\\Entity',1,'{\"id\":1,\"name\":\"MegaNet System\",\"security_level\":\"<p>ISO 27001<\\/p>\",\"contact_point\":\"<p>Helpdek<br>27, Rue des poire&nbsp;<br>12043 Mire-en-Mare le Bains<\\/p><p>helpdes@menetsys.org<\\/p>\",\"description\":\"<p>Fournisseur \\u00e9quipement r\\u00e9seau<\\/p>\",\"is_external\":\"1\",\"created_at\":\"2020-05-21 04:30:59\",\"updated_at\":\"2022-05-21 03:43:26\",\"deleted_at\":null}','127.0.0.1','2022-05-21 01:43:26','2022-05-21 01:43:26'),(4,'updated',12,'App\\Entity',1,'{\"id\":12,\"name\":\"Pierre et fils\",\"security_level\":\"<p>Certifications :&nbsp;<br>- ISO 9001<br>- ISO 27001<br>- ISO 31000<\\/p>\",\"contact_point\":\"<p>Paul Pierre<br>G\\u00e9rant<br>00 33 4943 432 423<\\/p>\",\"description\":\"<p>Description de l\'entit\\u00e9 de test<\\/p>\",\"is_external\":\"1\",\"created_at\":\"2020-07-06 15:37:54\",\"updated_at\":\"2022-05-21 03:44:43\",\"deleted_at\":null}','127.0.0.1','2022-05-21 01:44:43','2022-05-21 01:44:43');
+/*!40000 ALTER TABLE `audit_logs` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "bays"
+-- Dumping data for table `bay_wifi_terminal`
 --
 
-LOCK TABLES "bays" WRITE;
-/*!40000 ALTER TABLE "bays" DISABLE KEYS */;
-INSERT INTO "bays" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "room_id") VALUES (1,'BAIE 101','<p>Description de la baie 101</p>','2020-06-21 04:56:01','2021-10-19 16:45:21',NULL,7),(2,'BAIE 102','<p>Desciption baie 102</p>','2020-06-21 04:56:20','2020-06-21 04:56:20',NULL,1),(3,'BAIE 103','<p>Descripton baid 103</p>','2020-06-21 04:56:38','2020-06-21 04:56:38',NULL,1),(4,'BAIE 201','<p>Description baie 201</p>','2020-06-21 04:56:55','2020-06-21 04:56:55',NULL,2),(5,'BAIE 301','<p>Baie 301</p>','2020-07-15 18:03:07','2020-07-15 18:03:07',NULL,3),(6,'BAIE 501','<p>Baie 501</p>','2020-07-15 18:10:23','2020-07-15 18:10:23',NULL,5);
-/*!40000 ALTER TABLE "bays" ENABLE KEYS */;
+LOCK TABLES `bay_wifi_terminal` WRITE;
+/*!40000 ALTER TABLE `bay_wifi_terminal` DISABLE KEYS */;
+/*!40000 ALTER TABLE `bay_wifi_terminal` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "buildings"
+-- Dumping data for table `bays`
 --
 
-LOCK TABLES "buildings" WRITE;
-/*!40000 ALTER TABLE "buildings" DISABLE KEYS */;
-INSERT INTO "buildings" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "site_id", "camera", "badge") VALUES (1,'Building 1','<p>Description du building 1</p>','2020-06-21 04:37:21','2020-06-21 04:47:41',NULL,1,NULL,NULL),(2,'Building 2','<p>Description du building 2</p>','2020-06-21 04:37:36','2020-07-25 06:26:13',NULL,1,NULL,NULL),(3,'Building 3','<p>Description du building 3</p>','2020-06-21 04:37:48','2020-07-25 06:26:03',NULL,2,NULL,NULL),(4,'Building 4','<p>Description du building 4</p>','2020-06-21 04:38:03','2020-07-25 06:25:54',NULL,2,NULL,NULL),(5,'Building 5','<p>Descripion du building 5</p>','2020-06-21 04:38:16','2020-07-25 06:26:26',NULL,3,NULL,NULL),(6,'Test building','<p>Description</p>','2020-07-24 19:12:48','2020-07-24 19:14:08','2020-07-24 19:14:08',4,NULL,NULL),(7,'Building 0','<p>Le building zéro</p>','2020-08-21 13:10:15','2020-10-02 07:38:55',NULL,1,NULL,NULL),(8,'test','<p>test</p>','2020-11-06 13:44:22','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,1,0),(9,'test2','<p>test2</p>','2020-11-06 13:59:45','2020-11-06 14:06:50','2020-11-06 14:06:50',NULL,NULL,NULL),(10,'test3','<p>fdfsdfsd</p>','2020-11-06 14:07:07','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,NULL,NULL),(11,'test4',NULL,'2020-11-06 14:25:52','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,0,0);
-/*!40000 ALTER TABLE "buildings" ENABLE KEYS */;
+LOCK TABLES `bays` WRITE;
+/*!40000 ALTER TABLE `bays` DISABLE KEYS */;
+INSERT INTO `bays` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `room_id`) VALUES (1,'BAIE 101','<p>Description de la baie 101</p>','2020-06-21 04:56:01','2021-10-19 16:45:21',NULL,7),(2,'BAIE 102','<p>Desciption baie 102</p>','2020-06-21 04:56:20','2020-06-21 04:56:20',NULL,1),(3,'BAIE 103','<p>Descripton baid 103</p>','2020-06-21 04:56:38','2020-06-21 04:56:38',NULL,1),(4,'BAIE 201','<p>Description baie 201</p>','2020-06-21 04:56:55','2020-06-21 04:56:55',NULL,2),(5,'BAIE 301','<p>Baie 301</p>','2020-07-15 18:03:07','2020-07-15 18:03:07',NULL,3),(6,'BAIE 501','<p>Baie 501</p>','2020-07-15 18:10:23','2020-07-15 18:10:23',NULL,5);
+/*!40000 ALTER TABLE `bays` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "cartographer_m_application"
+-- Dumping data for table `buildings`
 --
 
-LOCK TABLES "cartographer_m_application" WRITE;
-/*!40000 ALTER TABLE "cartographer_m_application" DISABLE KEYS */;
-/*!40000 ALTER TABLE "cartographer_m_application" ENABLE KEYS */;
+LOCK TABLES `buildings` WRITE;
+/*!40000 ALTER TABLE `buildings` DISABLE KEYS */;
+INSERT INTO `buildings` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `camera`, `badge`) VALUES (1,'Building 1','<p>Description du building 1</p>','2020-06-21 04:37:21','2020-06-21 04:47:41',NULL,1,NULL,NULL),(2,'Building 2','<p>Description du building 2</p>','2020-06-21 04:37:36','2020-07-25 06:26:13',NULL,1,NULL,NULL),(3,'Building 3','<p>Description du building 3</p>','2020-06-21 04:37:48','2020-07-25 06:26:03',NULL,2,NULL,NULL),(4,'Building 4','<p>Description du building 4</p>','2020-06-21 04:38:03','2020-07-25 06:25:54',NULL,2,NULL,NULL),(5,'Building 5','<p>Descripion du building 5</p>','2020-06-21 04:38:16','2020-07-25 06:26:26',NULL,3,NULL,NULL),(6,'Test building','<p>Description</p>','2020-07-24 19:12:48','2020-07-24 19:14:08','2020-07-24 19:14:08',4,NULL,NULL),(7,'Building 0','<p>Le building zéro</p>','2020-08-21 13:10:15','2020-10-02 07:38:55',NULL,1,NULL,NULL),(8,'test','<p>test</p>','2020-11-06 13:44:22','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,1,0),(9,'test2','<p>test2</p>','2020-11-06 13:59:45','2020-11-06 14:06:50','2020-11-06 14:06:50',NULL,NULL,NULL),(10,'test3','<p>fdfsdfsd</p>','2020-11-06 14:07:07','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,NULL,NULL),(11,'test4',NULL,'2020-11-06 14:25:52','2020-11-06 14:26:18','2020-11-06 14:26:18',NULL,0,0);
+/*!40000 ALTER TABLE `buildings` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "certificate_logical_server"
+-- Dumping data for table `cartographer_m_application`
 --
 
-LOCK TABLES "certificate_logical_server" WRITE;
-/*!40000 ALTER TABLE "certificate_logical_server" DISABLE KEYS */;
-INSERT INTO "certificate_logical_server" ("certificate_id", "logical_server_id") VALUES (4,1),(5,2),(1,1),(2,1),(3,1),(7,1);
-/*!40000 ALTER TABLE "certificate_logical_server" ENABLE KEYS */;
+LOCK TABLES `cartographer_m_application` WRITE;
+/*!40000 ALTER TABLE `cartographer_m_application` DISABLE KEYS */;
+/*!40000 ALTER TABLE `cartographer_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "certificate_m_application"
+-- Dumping data for table `certificate_logical_server`
 --
 
-LOCK TABLES "certificate_m_application" WRITE;
-/*!40000 ALTER TABLE "certificate_m_application" DISABLE KEYS */;
-INSERT INTO "certificate_m_application" ("certificate_id", "m_application_id") VALUES (8,4);
-/*!40000 ALTER TABLE "certificate_m_application" ENABLE KEYS */;
+LOCK TABLES `certificate_logical_server` WRITE;
+/*!40000 ALTER TABLE `certificate_logical_server` DISABLE KEYS */;
+INSERT INTO `certificate_logical_server` (`certificate_id`, `logical_server_id`) VALUES (4,1),(5,2),(1,1),(2,1),(3,1),(7,1);
+/*!40000 ALTER TABLE `certificate_logical_server` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "certificates"
+-- Dumping data for table `certificate_m_application`
 --
 
-LOCK TABLES "certificates" WRITE;
-/*!40000 ALTER TABLE "certificates" DISABLE KEYS */;
-INSERT INTO "certificates" ("id", "name", "type", "description", "start_validity", "end_validity", "created_at", "updated_at", "deleted_at", "status") VALUES (1,'CERT01','DES3','<p>Certificat 01</p>','2020-10-27','2022-01-01','2021-07-14 08:28:47','2022-02-08 15:25:10',NULL,0),(2,'CERT02','AES 256','<p>Certificat numéro 02</p>','2021-07-14','2021-07-17','2021-07-14 08:33:33','2021-07-14 14:14:12',NULL,NULL),(3,'CERT03','AES 256','<p>Certificat numéro 3</p>','2021-09-23','2021-11-11','2021-07-14 10:35:41','2021-09-23 14:11:34',NULL,NULL),(4,'CERT04','DES3','<p>Certificat interne DES 3</p>',NULL,NULL,'2021-07-14 10:40:15','2021-07-14 10:40:15',NULL,NULL),(5,'CERT05','RSA 128','<p>Clé 05 avec RSA</p>',NULL,NULL,'2021-07-14 10:45:00','2021-07-14 10:45:00',NULL,NULL),(6,'CERT07','DES3','<p>cert 7</p>',NULL,NULL,'2021-07-14 12:44:12','2021-07-14 12:44:12',NULL,NULL),(7,'CERT08','DES3','<p>Master cert 08</p>','2021-06-15','2022-08-11','2021-08-11 18:33:42','2021-08-11 18:33:42',NULL,NULL),(8,'CERT09','DES3','<p>Test cert nine</p>','2021-09-25','2021-09-26','2021-09-23 14:17:20','2021-09-23 14:17:20',NULL,NULL);
-/*!40000 ALTER TABLE "certificates" ENABLE KEYS */;
+LOCK TABLES `certificate_m_application` WRITE;
+/*!40000 ALTER TABLE `certificate_m_application` DISABLE KEYS */;
+INSERT INTO `certificate_m_application` (`certificate_id`, `m_application_id`) VALUES (8,4);
+/*!40000 ALTER TABLE `certificate_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "database_entity"
+-- Dumping data for table `certificates`
 --
 
-LOCK TABLES "database_entity" WRITE;
-/*!40000 ALTER TABLE "database_entity" DISABLE KEYS */;
-INSERT INTO "database_entity" ("database_id", "entity_id") VALUES (1,1),(3,1),(4,1),(5,1),(6,1);
-/*!40000 ALTER TABLE "database_entity" ENABLE KEYS */;
+LOCK TABLES `certificates` WRITE;
+/*!40000 ALTER TABLE `certificates` DISABLE KEYS */;
+INSERT INTO `certificates` (`id`, `name`, `type`, `description`, `start_validity`, `end_validity`, `created_at`, `updated_at`, `deleted_at`, `status`) VALUES (1,'CERT01','DES3','<p>Certificat 01</p>','2020-10-27','2022-01-01','2021-07-14 08:28:47','2022-02-08 15:25:10',NULL,0),(2,'CERT02','AES 256','<p>Certificat numéro 02</p>','2021-07-14','2021-07-17','2021-07-14 08:33:33','2021-07-14 14:14:12',NULL,NULL),(3,'CERT03','AES 256','<p>Certificat numéro 3</p>','2021-09-23','2021-11-11','2021-07-14 10:35:41','2021-09-23 14:11:34',NULL,NULL),(4,'CERT04','DES3','<p>Certificat interne DES 3</p>',NULL,NULL,'2021-07-14 10:40:15','2021-07-14 10:40:15',NULL,NULL),(5,'CERT05','RSA 128','<p>Clé 05 avec RSA</p>',NULL,NULL,'2021-07-14 10:45:00','2021-07-14 10:45:00',NULL,NULL),(6,'CERT07','DES3','<p>cert 7</p>',NULL,NULL,'2021-07-14 12:44:12','2021-07-14 12:44:12',NULL,NULL),(7,'CERT08','DES3','<p>Master cert 08</p>','2021-06-15','2022-08-11','2021-08-11 18:33:42','2021-08-11 18:33:42',NULL,NULL),(8,'CERT09','DES3','<p>Test cert nine</p>','2021-09-25','2021-09-26','2021-09-23 14:17:20','2021-09-23 14:17:20',NULL,NULL);
+/*!40000 ALTER TABLE `certificates` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "database_information"
+-- Dumping data for table `database_entity`
 --
 
-LOCK TABLES "database_information" WRITE;
-/*!40000 ALTER TABLE "database_information" DISABLE KEYS */;
-INSERT INTO "database_information" ("database_id", "information_id") VALUES (1,1),(1,2),(1,3),(3,2),(3,3),(5,1),(4,2),(6,2),(6,3),(5,5);
-/*!40000 ALTER TABLE "database_information" ENABLE KEYS */;
+LOCK TABLES `database_entity` WRITE;
+/*!40000 ALTER TABLE `database_entity` DISABLE KEYS */;
+INSERT INTO `database_entity` (`database_id`, `entity_id`) VALUES (1,1),(3,1),(4,1),(5,1),(6,1);
+/*!40000 ALTER TABLE `database_entity` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "database_m_application"
+-- Dumping data for table `database_information`
 --
 
-LOCK TABLES "database_m_application" WRITE;
-/*!40000 ALTER TABLE "database_m_application" DISABLE KEYS */;
-INSERT INTO "database_m_application" ("m_application_id", "database_id") VALUES (2,3),(3,4),(3,1),(4,5),(4,6),(15,5),(15,4),(16,1);
-/*!40000 ALTER TABLE "database_m_application" ENABLE KEYS */;
+LOCK TABLES `database_information` WRITE;
+/*!40000 ALTER TABLE `database_information` DISABLE KEYS */;
+INSERT INTO `database_information` (`database_id`, `information_id`) VALUES (1,1),(1,2),(1,3),(3,2),(3,3),(5,1),(4,2),(6,2),(6,3),(5,5);
+/*!40000 ALTER TABLE `database_information` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "databases"
+-- Dumping data for table `database_m_application`
 --
 
-LOCK TABLES "databases" WRITE;
-/*!40000 ALTER TABLE "databases" DISABLE KEYS */;
-INSERT INTO "databases" ("id", "name", "description", "responsible", "type", "security_need_c", "external", "created_at", "updated_at", "deleted_at", "entity_resp_id", "security_need_i", "security_need_a", "security_need_t") VALUES (1,'Database 1','<p>Description Database 1</p>','Paul','MySQL',1,'Interne','2020-06-17 14:18:48','2021-05-14 10:19:45',NULL,2,2,3,4),(3,'Database 2','<p>Description database 2</p>','Paul','MySQL',1,'Interne','2020-06-17 14:19:24','2021-05-14 10:29:47',NULL,1,1,1,1),(4,'MainDB','<p>description de la base de données</p>','Paul','Oracle',2,'Interne','2020-07-01 15:08:57','2021-08-20 01:52:23',NULL,1,2,2,2),(5,'DB Compta','<p>Base de donnée de la compta</p>','Paul','MariaDB',2,'Interne','2020-08-24 15:58:23','2022-03-21 17:13:10',NULL,18,2,2,2),(6,'Data Warehouse','<p>Base de données du datawarehouse</p>','Jean','Oracle',2,'Interne','2021-05-14 10:24:02','2022-03-21 17:13:24',NULL,1,2,2,2);
-/*!40000 ALTER TABLE "databases" ENABLE KEYS */;
+LOCK TABLES `database_m_application` WRITE;
+/*!40000 ALTER TABLE `database_m_application` DISABLE KEYS */;
+INSERT INTO `database_m_application` (`m_application_id`, `database_id`) VALUES (2,3),(3,4),(3,1),(4,5),(4,6),(15,5),(15,4),(16,1);
+/*!40000 ALTER TABLE `database_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "dhcp_servers"
+-- Dumping data for table `databases`
 --
 
-LOCK TABLES "dhcp_servers" WRITE;
-/*!40000 ALTER TABLE "dhcp_servers" DISABLE KEYS */;
-INSERT INTO "dhcp_servers" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "address_ip") VALUES (1,'DHCP_1','<p>Serveur DHCP primaire</p>','2020-07-23 08:34:43','2021-10-19 09:03:07',NULL,'10.10.121.2'),(2,'DHCP_2','<p>Serveur DHCP secondaire</p>','2021-10-19 08:46:52','2021-10-19 09:23:36',NULL,'10.40.6.4');
-/*!40000 ALTER TABLE "dhcp_servers" ENABLE KEYS */;
+LOCK TABLES `databases` WRITE;
+/*!40000 ALTER TABLE `databases` DISABLE KEYS */;
+INSERT INTO `databases` (`id`, `name`, `description`, `responsible`, `type`, `security_need_c`, `external`, `created_at`, `updated_at`, `deleted_at`, `entity_resp_id`, `security_need_i`, `security_need_a`, `security_need_t`) VALUES (1,'Database 1','<p>Description Database 1</p>','Paul','MySQL',1,'Interne','2020-06-17 14:18:48','2021-05-14 10:19:45',NULL,2,2,3,4),(3,'Database 2','<p>Description database 2</p>','Paul','MySQL',1,'Interne','2020-06-17 14:19:24','2021-05-14 10:29:47',NULL,1,1,1,1),(4,'MainDB','<p>description de la base de données</p>','Paul','Oracle',2,'Interne','2020-07-01 15:08:57','2021-08-20 01:52:23',NULL,1,2,2,2),(5,'DB Compta','<p>Base de donnée de la compta</p>','Paul','MariaDB',2,'Interne','2020-08-24 15:58:23','2022-03-21 17:13:10',NULL,18,2,2,2),(6,'Data Warehouse','<p>Base de données du datawarehouse</p>','Jean','Oracle',2,'Interne','2021-05-14 10:24:02','2022-03-21 17:13:24',NULL,1,2,2,2);
+/*!40000 ALTER TABLE `databases` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "dnsservers"
+-- Dumping data for table `dhcp_servers`
 --
 
-LOCK TABLES "dnsservers" WRITE;
-/*!40000 ALTER TABLE "dnsservers" DISABLE KEYS */;
-INSERT INTO "dnsservers" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "address_ip") VALUES (1,'DNS_1','<p>Serveur DNS primaire</p>','2020-07-23 08:31:39','2021-11-16 16:55:11',NULL,'10.10.3.4'),(2,'DNS_2','<p>Serveur DNS secondaire</p>','2020-07-23 08:31:50','2021-10-19 09:10:45',NULL,'10.30.2.3'),(3,'DNS_3','<p>Troisième serveur DNS</p>','2021-10-19 08:39:25','2021-10-19 08:41:09',NULL,'10.10.10.1');
-/*!40000 ALTER TABLE "dnsservers" ENABLE KEYS */;
+LOCK TABLES `dhcp_servers` WRITE;
+/*!40000 ALTER TABLE `dhcp_servers` DISABLE KEYS */;
+INSERT INTO `dhcp_servers` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `address_ip`) VALUES (1,'DHCP_1','<p>Serveur DHCP primaire</p>','2020-07-23 08:34:43','2021-10-19 09:03:07',NULL,'10.10.121.2'),(2,'DHCP_2','<p>Serveur DHCP secondaire</p>','2021-10-19 08:46:52','2021-10-19 09:23:36',NULL,'10.40.6.4');
+/*!40000 ALTER TABLE `dhcp_servers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "domaine_ad_forest_ad"
+-- Dumping data for table `dnsservers`
 --
 
-LOCK TABLES "domaine_ad_forest_ad" WRITE;
-/*!40000 ALTER TABLE "domaine_ad_forest_ad" DISABLE KEYS */;
-INSERT INTO "domaine_ad_forest_ad" ("forest_ad_id", "domaine_ad_id") VALUES (1,1),(2,1),(1,3),(2,5),(1,4);
-/*!40000 ALTER TABLE "domaine_ad_forest_ad" ENABLE KEYS */;
+LOCK TABLES `dnsservers` WRITE;
+/*!40000 ALTER TABLE `dnsservers` DISABLE KEYS */;
+INSERT INTO `dnsservers` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `address_ip`) VALUES (1,'DNS_1','<p>Serveur DNS primaire</p>','2020-07-23 08:31:39','2021-11-16 16:55:11',NULL,'10.10.3.4'),(2,'DNS_2','<p>Serveur DNS secondaire</p>','2020-07-23 08:31:50','2021-10-19 09:10:45',NULL,'10.30.2.3'),(3,'DNS_3','<p>Troisième serveur DNS</p>','2021-10-19 08:39:25','2021-10-19 08:41:09',NULL,'10.10.10.1');
+/*!40000 ALTER TABLE `dnsservers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "domaine_ads"
+-- Dumping data for table `domaine_ad_forest_ad`
 --
 
-LOCK TABLES "domaine_ads" WRITE;
-/*!40000 ALTER TABLE "domaine_ads" DISABLE KEYS */;
-INSERT INTO "domaine_ads" ("id", "name", "description", "domain_ctrl_cnt", "user_count", "machine_count", "relation_inter_domaine", "created_at", "updated_at", "deleted_at") VALUES (1,'Dom1','<p>Domaine AD1</p>',3,2000,800,'Non','2020-07-03 07:51:06','2020-07-03 07:51:06',NULL),(2,'test domain','<p>this is a test</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:24:52','2021-05-27 13:29:15','2021-05-27 13:29:15'),(3,'Dom2','<p>Second domaine active directory</p>',2,100,1,'Néant','2021-05-27 13:29:43','2021-05-27 13:29:43',NULL),(4,'Dom5','<p>Domaine cinq</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:39:08','2021-05-27 13:39:08',NULL),(5,'Dom4','<p>Domaine quatre</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:39:20','2021-05-27 13:39:20',NULL);
-/*!40000 ALTER TABLE "domaine_ads" ENABLE KEYS */;
+LOCK TABLES `domaine_ad_forest_ad` WRITE;
+/*!40000 ALTER TABLE `domaine_ad_forest_ad` DISABLE KEYS */;
+INSERT INTO `domaine_ad_forest_ad` (`forest_ad_id`, `domaine_ad_id`) VALUES (1,1),(2,1),(1,3),(2,5),(1,4);
+/*!40000 ALTER TABLE `domaine_ad_forest_ad` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "entities"
+-- Dumping data for table `domaine_ads`
 --
 
-LOCK TABLES "entities" WRITE;
-/*!40000 ALTER TABLE "entities" DISABLE KEYS */;
-INSERT INTO "entities" ("id", "name", "security_level", "contact_point", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'MegaNet System','<p>ISO 27001</p>','<p>Helpdek<br>27, Rue des poire&nbsp;<br>12043 Mire-en-Mare le Bains</p><p>helpdes@menetsys.org</p>','<p>Fournisseur équipement réseau</p>','2020-05-21 02:30:59','2021-10-27 09:28:17',NULL),(2,'Entité1','<p>Néant</p>','<ul><li>Commercial</li><li>Service Delivery</li><li>Helpdesk</li></ul>','<p>Entité de tests1</p>','2020-05-21 02:31:17','2021-05-23 12:59:11',NULL),(3,'CHdN','3','RSSI du CHdN','<p>Centre Hospitalier du Nord</p>','2020-05-21 02:43:41','2021-05-13 08:20:32','2021-05-13 08:20:32'),(4,'Entité3','<p>ISO 9001</p>','<p>Point de contact de la troisième entité</p>','<p>Description de la troisième entité.</p>','2020-05-21 02:44:03','2021-07-20 19:20:37',NULL),(5,'entité6','<p>Néant</p>','<p>support_informatque@entite6.fr</p>','<p>Description de l\'entité six</p>','2020-05-21 02:44:18','2021-05-23 13:03:15',NULL),(6,'Entité4','<p>ISO 27001</p>','<p>Pierre Pinon<br>Tel: 00 34 392 484 22</p>','<p>Description de l\'entté quatre</p>','2020-05-21 02:45:14','2021-05-23 13:01:17',NULL),(7,'Entité5','<p>Néant</p>','<p>Servicdesk@entite5.fr</p>','<p>Description de l\'entité 5</p>','2020-05-21 03:38:41','2021-05-23 13:02:16',NULL),(8,'Entité2','<p>ISO 27001</p>','<p>Point de contact de l\'entité 2</p>','<p>Description de l\'entité 2</p>','2020-05-21 03:54:22','2021-05-23 13:00:03',NULL),(9,'NetworkSys','<p>ISO 27001</p>','<p>support@networksys.fr</p>','<p>Description de l’entité NetworkSys</p>','2020-05-21 06:25:15','2021-05-23 13:04:06',NULL),(10,'Agence eSanté','<p>Néant</p>','<p>helpdesk@esante.lu</p>','<p>Agence Nationale des information partagées dans le domaine de la santé</p><ul><li>a</li><li>b</li><li>c</li></ul><p>+-------+<br>+ TOTO +<br>+-------+</p><p>&lt;&lt;&lt;&lt;&lt;&lt; &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;</p>','2020-05-21 06:25:26','2021-05-13 08:20:32','2021-05-13 08:20:32'),(11,'Test','4',NULL,'<p>Test</p>','2020-07-02 15:37:29','2020-07-02 15:37:44','2020-07-02 15:37:44'),(12,'Pierre et fils','<p>Certifications :&nbsp;<br>- ISO 9001<br>- ISO 27001<br>- ISO 31000</p>','<p>Paul Pierre<br>Gérant<br>00 33 4943 432 423</p>','<p>Description de l\'entité de test</p>','2020-07-06 13:37:54','2022-04-19 14:58:37',NULL),(13,'Nestor','<p>Haut niveau</p>','<p>Paul, Pierre et Jean</p>','<p>Description de Nestor</p>','2020-08-12 16:11:31','2020-08-12 16:12:13',NULL),(14,'0001',NULL,NULL,'<p>rrzerze</p>','2021-06-15 15:16:31','2021-06-15 15:17:08','2021-06-15 15:17:08'),(15,'002',NULL,NULL,'<p>sdqsfsd</p>','2021-06-15 15:16:41','2021-06-15 15:17:08','2021-06-15 15:17:08'),(16,'003',NULL,NULL,'<p>dsqdsq</p>','2021-06-15 15:16:51','2021-06-15 15:17:08','2021-06-15 15:17:08'),(17,'004',NULL,NULL,'<p>dqqqsdqs</p>','2021-06-15 15:17:01','2021-06-15 15:17:08','2021-06-15 15:17:08'),(18,'Acme corp.','<p>None sorry...</p>','<p>Do not call me, I will call you back.</p>','<p>Looney tunes academy</p>','2021-09-07 18:07:16','2022-05-06 08:45:29',NULL),(19,'HAL','<p>Top security certification</p>','<p>hal@corp.com</p>','<p>Very big HAL corporation</p>','2021-09-07 18:08:56','2021-09-07 18:09:17',NULL),(20,'ATest1',NULL,NULL,NULL,'2022-04-25 12:43:46','2022-04-25 12:44:02','2022-04-25 12:44:02'),(21,'ATest2',NULL,NULL,NULL,'2022-04-25 12:43:56','2022-04-25 12:44:02','2022-04-25 12:44:02');
-/*!40000 ALTER TABLE "entities" ENABLE KEYS */;
+LOCK TABLES `domaine_ads` WRITE;
+/*!40000 ALTER TABLE `domaine_ads` DISABLE KEYS */;
+INSERT INTO `domaine_ads` (`id`, `name`, `description`, `domain_ctrl_cnt`, `user_count`, `machine_count`, `relation_inter_domaine`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Dom1','<p>Domaine AD1</p>',3,2000,800,'Non','2020-07-03 07:51:06','2020-07-03 07:51:06',NULL),(2,'test domain','<p>this is a test</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:24:52','2021-05-27 13:29:15','2021-05-27 13:29:15'),(3,'Dom2','<p>Second domaine active directory</p>',2,100,1,'Néant','2021-05-27 13:29:43','2021-05-27 13:29:43',NULL),(4,'Dom5','<p>Domaine cinq</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:39:08','2021-05-27 13:39:08',NULL),(5,'Dom4','<p>Domaine quatre</p>',NULL,NULL,NULL,NULL,'2021-05-27 13:39:20','2021-05-27 13:39:20',NULL);
+/*!40000 ALTER TABLE `domaine_ads` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "entity_m_application"
+-- Dumping data for table `entities`
 --
 
-LOCK TABLES "entity_m_application" WRITE;
-/*!40000 ALTER TABLE "entity_m_application" DISABLE KEYS */;
-INSERT INTO "entity_m_application" ("m_application_id", "entity_id") VALUES (2,1),(5,1),(7,2),(9,1),(10,1),(2,2),(11,1),(1,2),(1,8),(3,8),(4,8),(4,4),(16,2);
-/*!40000 ALTER TABLE "entity_m_application" ENABLE KEYS */;
+LOCK TABLES `entities` WRITE;
+/*!40000 ALTER TABLE `entities` DISABLE KEYS */;
+INSERT INTO `entities` (`id`, `name`, `security_level`, `contact_point`, `description`, `is_external`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'MegaNet System','<p>ISO 27001</p>','<p>Helpdek<br>27, Rue des poire&nbsp;<br>12043 Mire-en-Mare le Bains</p><p>helpdes@menetsys.org</p>','<p>Fournisseur équipement réseau</p>',1,'2020-05-21 02:30:59','2022-05-20 15:30:00',NULL),(2,'Entité1','<p>Néant</p>','<ul><li>Commercial</li><li>Service Delivery</li><li>Helpdesk</li></ul>','<p>Entité de tests1</p>',0,'2020-05-21 02:31:17','2021-05-23 12:59:11',NULL),(3,'CHdN','3','RSSI du CHdN','<p>Centre Hospitalier du Nord</p>',0,'2020-05-21 02:43:41','2021-05-13 08:20:32','2021-05-13 08:20:32'),(4,'Entité3','<p>ISO 9001</p>','<p>Point de contact de la troisième entité</p>','<p>Description de la troisième entité.</p>',0,'2020-05-21 02:44:03','2021-07-20 19:20:37',NULL),(5,'entité6','<p>Néant</p>','<p>support_informatque@entite6.fr</p>','<p>Description de l\'entité six</p>',0,'2020-05-21 02:44:18','2021-05-23 13:03:15',NULL),(6,'Entité4','<p>ISO 27001</p>','<p>Pierre Pinon<br>Tel: 00 34 392 484 22</p>','<p>Description de l\'entté quatre</p>',0,'2020-05-21 02:45:14','2021-05-23 13:01:17',NULL),(7,'Entité5','<p>Néant</p>','<p>Servicdesk@entite5.fr</p>','<p>Description de l\'entité 5</p>',0,'2020-05-21 03:38:41','2021-05-23 13:02:16',NULL),(8,'Entité2','<p>ISO 27001</p>','<p>Point de contact de l\'entité 2</p>','<p>Description de l\'entité 2</p>',0,'2020-05-21 03:54:22','2021-05-23 13:00:03',NULL),(9,'NetworkSys','<p>ISO 27001</p>','<p>support@networksys.fr</p>','<p>Description de l’entité NetworkSys</p>',1,'2020-05-21 06:25:15','2022-05-20 15:30:00',NULL),(10,'Agence eSanté','<p>Néant</p>','<p>helpdesk@esante.lu</p>','<p>Agence Nationale des information partagées dans le domaine de la santé</p><ul><li>a</li><li>b</li><li>c</li></ul><p>+-------+<br>+ TOTO +<br>+-------+</p><p>&lt;&lt;&lt;&lt;&lt;&lt; &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;</p>',0,'2020-05-21 06:25:26','2021-05-13 08:20:32','2021-05-13 08:20:32'),(11,'Test','4',NULL,'<p>Test</p>',0,'2020-07-02 15:37:29','2020-07-02 15:37:44','2020-07-02 15:37:44'),(12,'Pierre et fils','<p>Certifications :&nbsp;<br>- ISO 9001<br>- ISO 27001<br>- ISO 31000</p>','<p>Paul Pierre<br>Gérant<br>00 33 4943 432 423</p>','<p>Description de l\'entité de test</p>',1,'2020-07-06 13:37:54','2022-05-20 15:30:00',NULL),(13,'Nestor','<p>Haut niveau</p>','<p>Paul, Pierre et Jean</p>','<p>Description de Nestor</p>',0,'2020-08-12 16:11:31','2020-08-12 16:12:13',NULL),(14,'0001',NULL,NULL,'<p>rrzerze</p>',0,'2021-06-15 15:16:31','2021-06-15 15:17:08','2021-06-15 15:17:08'),(15,'002',NULL,NULL,'<p>sdqsfsd</p>',0,'2021-06-15 15:16:41','2021-06-15 15:17:08','2021-06-15 15:17:08'),(16,'003',NULL,NULL,'<p>dsqdsq</p>',0,'2021-06-15 15:16:51','2021-06-15 15:17:08','2021-06-15 15:17:08'),(17,'004',NULL,NULL,'<p>dqqqsdqs</p>',0,'2021-06-15 15:17:01','2021-06-15 15:17:08','2021-06-15 15:17:08'),(18,'Acme corp.','<p>None sorry...</p>','<p>Do not call me, I will call you back.</p>','<p>Looney tunes academy</p>',1,'2021-09-07 18:07:16','2022-05-20 15:30:00',NULL),(19,'HAL','<p>Top security certification</p>','<p>hal@corp.com</p>','<p>Very big HAL corporation</p>',0,'2021-09-07 18:08:56','2021-09-07 18:09:17',NULL),(20,'ATest1',NULL,NULL,NULL,0,'2022-04-25 12:43:46','2022-04-25 12:44:02','2022-04-25 12:44:02'),(21,'ATest2',NULL,NULL,NULL,0,'2022-04-25 12:43:56','2022-04-25 12:44:02','2022-04-25 12:44:02');
+/*!40000 ALTER TABLE `entities` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "entity_process"
+-- Dumping data for table `entity_m_application`
 --
 
-LOCK TABLES "entity_process" WRITE;
-/*!40000 ALTER TABLE "entity_process" DISABLE KEYS */;
-INSERT INTO "entity_process" ("process_id", "entity_id") VALUES (1,1),(2,1),(3,1),(1,13),(3,13),(4,1),(7,3),(9,4),(2,8),(4,6),(4,7),(9,5),(1,9),(2,9),(3,9),(4,9),(9,9),(1,12),(1,2),(4,18),(3,19);
-/*!40000 ALTER TABLE "entity_process" ENABLE KEYS */;
+LOCK TABLES `entity_m_application` WRITE;
+/*!40000 ALTER TABLE `entity_m_application` DISABLE KEYS */;
+INSERT INTO `entity_m_application` (`m_application_id`, `entity_id`) VALUES (2,1),(5,1),(7,2),(9,1),(10,1),(2,2),(11,1),(1,2),(1,8),(3,8),(4,8),(4,4),(16,2);
+/*!40000 ALTER TABLE `entity_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "external_connected_entities"
+-- Dumping data for table `entity_process`
 --
 
-LOCK TABLES "external_connected_entities" WRITE;
-/*!40000 ALTER TABLE "external_connected_entities" DISABLE KEYS */;
-INSERT INTO "external_connected_entities" ("id", "name", "responsible_sec", "contacts", "created_at", "updated_at", "deleted_at") VALUES (1,'Entité externe 1','Nestor','Marcel','2020-07-23 07:59:25','2020-07-23 07:59:25',NULL),(2,'Entité externe 2','Philippe','it@external.corp','2021-08-17 17:52:26','2021-08-17 17:52:26',NULL);
-/*!40000 ALTER TABLE "external_connected_entities" ENABLE KEYS */;
+LOCK TABLES `entity_process` WRITE;
+/*!40000 ALTER TABLE `entity_process` DISABLE KEYS */;
+INSERT INTO `entity_process` (`process_id`, `entity_id`) VALUES (1,1),(2,1),(3,1),(1,13),(3,13),(4,1),(7,3),(9,4),(2,8),(4,6),(4,7),(9,5),(1,9),(2,9),(3,9),(4,9),(9,9),(1,12),(1,2),(4,18),(3,19);
+/*!40000 ALTER TABLE `entity_process` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "external_connected_entity_network"
+-- Dumping data for table `external_connected_entities`
 --
 
-LOCK TABLES "external_connected_entity_network" WRITE;
-/*!40000 ALTER TABLE "external_connected_entity_network" DISABLE KEYS */;
-INSERT INTO "external_connected_entity_network" ("external_connected_entity_id", "network_id") VALUES (1,1),(2,2);
-/*!40000 ALTER TABLE "external_connected_entity_network" ENABLE KEYS */;
+LOCK TABLES `external_connected_entities` WRITE;
+/*!40000 ALTER TABLE `external_connected_entities` DISABLE KEYS */;
+INSERT INTO `external_connected_entities` (`id`, `name`, `responsible_sec`, `contacts`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Entité externe 1','Nestor','Marcel','2020-07-23 07:59:25','2020-07-23 07:59:25',NULL),(2,'Entité externe 2','Philippe','it@external.corp','2021-08-17 17:52:26','2021-08-17 17:52:26',NULL);
+/*!40000 ALTER TABLE `external_connected_entities` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "fluxes"
+-- Dumping data for table `external_connected_entity_network`
 --
 
-LOCK TABLES "fluxes" WRITE;
-/*!40000 ALTER TABLE "fluxes" DISABLE KEYS */;
-INSERT INTO "fluxes" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "application_source_id", "service_source_id", "module_source_id", "database_source_id", "application_dest_id", "service_dest_id", "module_dest_id", "database_dest_id", "crypted", "bidirectional") VALUES (2,'FluxA','<p>Description du flux A</p>','2020-06-17 14:50:59','2021-09-29 06:02:26',NULL,1,NULL,NULL,NULL,2,NULL,NULL,NULL,0,1),(3,'FluxC','<p>Flux de test</p>','2020-07-07 13:58:22','2021-09-23 17:04:30',NULL,2,NULL,NULL,NULL,3,NULL,NULL,NULL,1,NULL),(4,'FluxB','<p>Flux de test 3</p>','2020-07-07 14:01:10','2021-09-29 06:07:54',NULL,NULL,NULL,4,NULL,2,NULL,NULL,NULL,1,1),(5,'Sync_DB','<p>Description du flux 01</p>','2020-07-23 10:44:35','2021-10-10 11:16:32',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,3,1,0),(6,'Flux_MOD_01','<p>Fuld module</p>','2020-07-23 10:48:20','2021-09-29 05:59:35',NULL,NULL,NULL,3,NULL,NULL,NULL,2,NULL,0,0),(7,'Flux_SER_01','Description du flux service 01','2020-07-23 10:51:41','2020-07-23 10:51:41',NULL,NULL,3,NULL,NULL,NULL,4,NULL,NULL,0,NULL),(8,'Fulx 07','Description du flux 07','2020-09-05 04:56:57','2020-09-05 04:57:36',NULL,NULL,1,NULL,NULL,NULL,2,NULL,NULL,1,NULL),(9,'FLux DB_02','<p>Description du flux 2</p>','2020-09-05 05:12:05','2021-09-29 05:59:19',NULL,2,NULL,NULL,NULL,NULL,NULL,2,NULL,0,0),(10,'SRV10_to_SRV11','<p>Transfert from SRV10 to SRV11</p>','2021-08-02 15:13:31','2021-08-02 15:13:31',NULL,NULL,10,NULL,NULL,NULL,11,NULL,NULL,0,NULL),(11,'SRV4_to_SRV10',NULL,'2021-08-02 15:13:57','2021-08-02 15:13:57',NULL,NULL,5,NULL,NULL,NULL,10,NULL,NULL,1,NULL),(12,'SRV6_to_SRV10','<p>service 6 to service 10</p>','2021-08-02 15:14:36','2021-08-02 15:14:36',NULL,NULL,7,NULL,NULL,NULL,10,NULL,NULL,1,NULL),(13,'Syncy System',NULL,'2021-08-02 18:01:21','2021-08-02 18:01:21',NULL,NULL,10,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL),(14,'00001',NULL,'2021-09-01 07:00:09','2021-09-01 07:00:21','2021-09-01 07:00:21',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL),(15,'0002',NULL,'2021-09-01 07:00:15','2021-09-01 07:00:21','2021-09-01 07:00:21',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL);
-/*!40000 ALTER TABLE "fluxes" ENABLE KEYS */;
+LOCK TABLES `external_connected_entity_network` WRITE;
+/*!40000 ALTER TABLE `external_connected_entity_network` DISABLE KEYS */;
+INSERT INTO `external_connected_entity_network` (`external_connected_entity_id`, `network_id`) VALUES (1,1),(2,2);
+/*!40000 ALTER TABLE `external_connected_entity_network` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "forest_ads"
+-- Dumping data for table `fluxes`
 --
 
-LOCK TABLES "forest_ads" WRITE;
-/*!40000 ALTER TABLE "forest_ads" DISABLE KEYS */;
-INSERT INTO "forest_ads" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "zone_admin_id") VALUES (1,'AD1','<p>Foret de l\'AD 1</p>','2020-07-03 07:50:07','2020-07-03 07:50:29',NULL,1),(2,'AD2','<p>Foret de l\'AD2</p>','2020-07-03 07:50:19','2020-07-03 07:50:19',NULL,1);
-/*!40000 ALTER TABLE "forest_ads" ENABLE KEYS */;
+LOCK TABLES `fluxes` WRITE;
+/*!40000 ALTER TABLE `fluxes` DISABLE KEYS */;
+INSERT INTO `fluxes` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `application_source_id`, `service_source_id`, `module_source_id`, `database_source_id`, `application_dest_id`, `service_dest_id`, `module_dest_id`, `database_dest_id`, `crypted`, `bidirectional`) VALUES (2,'FluxA','<p>Description du flux A</p>','2020-06-17 14:50:59','2021-09-29 06:02:26',NULL,1,NULL,NULL,NULL,2,NULL,NULL,NULL,0,1),(3,'FluxC','<p>Flux de test</p>','2020-07-07 13:58:22','2021-09-23 17:04:30',NULL,2,NULL,NULL,NULL,3,NULL,NULL,NULL,1,NULL),(4,'FluxB','<p>Flux de test 3</p>','2020-07-07 14:01:10','2021-09-29 06:07:54',NULL,NULL,NULL,4,NULL,2,NULL,NULL,NULL,1,1),(5,'Sync_DB','<p>Description du flux 01</p>','2020-07-23 10:44:35','2021-10-10 11:16:32',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,3,1,0),(6,'Flux_MOD_01','<p>Fuld module</p>','2020-07-23 10:48:20','2021-09-29 05:59:35',NULL,NULL,NULL,3,NULL,NULL,NULL,2,NULL,0,0),(7,'Flux_SER_01','Description du flux service 01','2020-07-23 10:51:41','2020-07-23 10:51:41',NULL,NULL,3,NULL,NULL,NULL,4,NULL,NULL,0,NULL),(8,'Fulx 07','Description du flux 07','2020-09-05 04:56:57','2020-09-05 04:57:36',NULL,NULL,1,NULL,NULL,NULL,2,NULL,NULL,1,NULL),(9,'FLux DB_02','<p>Description du flux 2</p>','2020-09-05 05:12:05','2021-09-29 05:59:19',NULL,2,NULL,NULL,NULL,NULL,NULL,2,NULL,0,0),(10,'SRV10_to_SRV11','<p>Transfert from SRV10 to SRV11</p>','2021-08-02 15:13:31','2021-08-02 15:13:31',NULL,NULL,10,NULL,NULL,NULL,11,NULL,NULL,0,NULL),(11,'SRV4_to_SRV10',NULL,'2021-08-02 15:13:57','2021-08-02 15:13:57',NULL,NULL,5,NULL,NULL,NULL,10,NULL,NULL,1,NULL),(12,'SRV6_to_SRV10','<p>service 6 to service 10</p>','2021-08-02 15:14:36','2021-08-02 15:14:36',NULL,NULL,7,NULL,NULL,NULL,10,NULL,NULL,1,NULL),(13,'Syncy System',NULL,'2021-08-02 18:01:21','2021-08-02 18:01:21',NULL,NULL,10,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL),(14,'00001',NULL,'2021-09-01 07:00:09','2021-09-01 07:00:21','2021-09-01 07:00:21',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL),(15,'0002',NULL,'2021-09-01 07:00:15','2021-09-01 07:00:21','2021-09-01 07:00:21',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL);
+/*!40000 ALTER TABLE `fluxes` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "gateways"
+-- Dumping data for table `forest_ads`
 --
 
-LOCK TABLES "gateways" WRITE;
-/*!40000 ALTER TABLE "gateways" DISABLE KEYS */;
-INSERT INTO "gateways" ("id", "name", "description", "ip", "authentification", "created_at", "updated_at", "deleted_at") VALUES (1,'GW01','<p>Gateway 01 vers réseau médor</p>','123.5.6.4/12','Carte à puce','2020-07-13 17:34:45','2020-07-13 17:34:45',NULL),(2,'Workspace One','<p>Test workspace One</p>','10.10.10.1','Token','2021-04-17 19:32:57','2021-04-17 19:40:31','2021-04-17 19:40:31'),(3,'PubicGW','<p>Public Gateway</p>','10.10.10.1','Token','2021-04-17 19:39:04','2021-04-17 19:40:25','2021-04-17 19:40:25'),(4,'PublicGW','<p>Public gateway</p>','8.8.8.8','Token','2021-04-17 19:40:48','2021-04-17 19:48:34',NULL),(5,'GW02','<p>Second gateway</p>',NULL,'Token','2021-05-18 18:27:13','2021-08-18 18:04:23',NULL);
-/*!40000 ALTER TABLE "gateways" ENABLE KEYS */;
+LOCK TABLES `forest_ads` WRITE;
+/*!40000 ALTER TABLE `forest_ads` DISABLE KEYS */;
+INSERT INTO `forest_ads` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `zone_admin_id`) VALUES (1,'AD1','<p>Foret de l\'AD 1</p>','2020-07-03 07:50:07','2020-07-03 07:50:29',NULL,1),(2,'AD2','<p>Foret de l\'AD2</p>','2020-07-03 07:50:19','2020-07-03 07:50:19',NULL,1);
+/*!40000 ALTER TABLE `forest_ads` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "information"
+-- Dumping data for table `gateways`
 --
 
-LOCK TABLES "information" WRITE;
-/*!40000 ALTER TABLE "information" DISABLE KEYS */;
-INSERT INTO "information" ("id", "name", "description", "owner", "administrator", "storage", "security_need_c", "sensitivity", "constraints", "created_at", "updated_at", "deleted_at", "security_need_i", "security_need_a", "security_need_t") VALUES (1,'Information 1','<p>Description de l\'information 1</p>','Luc',NULL,'externe',1,'Donnée à caractère personnel','<p>Description des contraintes règlementaires et normatives</p>','2020-06-13 00:06:43','2021-11-04 07:43:27',NULL,3,2,2),(2,'information 2','<p>Description de l\'information</p>','Nestor','Nom de l\'administrateur','externe',2,'Donnée à caractère personnel',NULL,'2020-06-13 00:09:13','2021-08-19 16:42:53',NULL,1,1,1),(3,'information 3','<p>Descripton de l\'information 3</p>','Paul','Jean','Local',4,'Donnée à caractère personnel',NULL,'2020-06-13 00:10:07','2021-09-28 17:42:07',NULL,4,3,4),(4,'Information de test','<p>decription du test</p>','RSSI','Paul','Local',1,'Technical',NULL,'2020-07-01 15:00:37','2021-08-19 16:45:52',NULL,1,1,1),(5,'Données du client','<p>Données d\'identification du client</p>','Nestor','Paul','Local',2,'Donnée à caractère personnel','<p>RGPD</p>','2021-05-14 10:50:09','2022-03-21 17:12:30',NULL,2,2,2);
-/*!40000 ALTER TABLE "information" ENABLE KEYS */;
+LOCK TABLES `gateways` WRITE;
+/*!40000 ALTER TABLE `gateways` DISABLE KEYS */;
+INSERT INTO `gateways` (`id`, `name`, `description`, `ip`, `authentification`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'GW01','<p>Gateway 01 vers réseau médor</p>','123.5.6.4/12','Carte à puce','2020-07-13 17:34:45','2020-07-13 17:34:45',NULL),(2,'Workspace One','<p>Test workspace One</p>','10.10.10.1','Token','2021-04-17 19:32:57','2021-04-17 19:40:31','2021-04-17 19:40:31'),(3,'PubicGW','<p>Public Gateway</p>','10.10.10.1','Token','2021-04-17 19:39:04','2021-04-17 19:40:25','2021-04-17 19:40:25'),(4,'PublicGW','<p>Public gateway</p>','8.8.8.8','Token','2021-04-17 19:40:48','2021-04-17 19:48:34',NULL),(5,'GW02','<p>Second gateway</p>',NULL,'Token','2021-05-18 18:27:13','2021-08-18 18:04:23',NULL);
+/*!40000 ALTER TABLE `gateways` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "information_process"
+-- Dumping data for table `information`
 --
 
-LOCK TABLES "information_process" WRITE;
-/*!40000 ALTER TABLE "information_process" DISABLE KEYS */;
-INSERT INTO "information_process" ("information_id", "process_id") VALUES (3,2),(4,3),(4,4),(4,1),(1,4),(2,9),(5,1),(5,2),(5,4),(5,9);
-/*!40000 ALTER TABLE "information_process" ENABLE KEYS */;
+LOCK TABLES `information` WRITE;
+/*!40000 ALTER TABLE `information` DISABLE KEYS */;
+INSERT INTO `information` (`id`, `name`, `description`, `owner`, `administrator`, `storage`, `security_need_c`, `sensitivity`, `constraints`, `created_at`, `updated_at`, `deleted_at`, `security_need_i`, `security_need_a`, `security_need_t`) VALUES (1,'Information 1','<p>Description de l\'information 1</p>','Luc',NULL,'externe',1,'Donnée à caractère personnel','<p>Description des contraintes règlementaires et normatives</p>','2020-06-13 00:06:43','2021-11-04 07:43:27',NULL,3,2,2),(2,'information 2','<p>Description de l\'information</p>','Nestor','Nom de l\'administrateur','externe',2,'Donnée à caractère personnel',NULL,'2020-06-13 00:09:13','2021-08-19 16:42:53',NULL,1,1,1),(3,'information 3','<p>Descripton de l\'information 3</p>','Paul','Jean','Local',4,'Donnée à caractère personnel',NULL,'2020-06-13 00:10:07','2021-09-28 17:42:07',NULL,4,3,4),(4,'Information de test','<p>decription du test</p>','RSSI','Paul','Local',1,'Technical',NULL,'2020-07-01 15:00:37','2021-08-19 16:45:52',NULL,1,1,1),(5,'Données du client','<p>Données d\'identification du client</p>','Nestor','Paul','Local',2,'Donnée à caractère personnel','<p>RGPD</p>','2021-05-14 10:50:09','2022-03-21 17:12:30',NULL,2,2,2);
+/*!40000 ALTER TABLE `information` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "lan_man"
+-- Dumping data for table `information_process`
 --
 
-LOCK TABLES "lan_man" WRITE;
-/*!40000 ALTER TABLE "lan_man" DISABLE KEYS */;
-INSERT INTO "lan_man" ("man_id", "lan_id") VALUES (1,1),(2,1),(2,2),(2,3);
-/*!40000 ALTER TABLE "lan_man" ENABLE KEYS */;
+LOCK TABLES `information_process` WRITE;
+/*!40000 ALTER TABLE `information_process` DISABLE KEYS */;
+INSERT INTO `information_process` (`information_id`, `process_id`) VALUES (3,2),(4,3),(4,4),(4,1),(1,4),(2,9),(5,1),(5,2),(5,4),(5,9);
+/*!40000 ALTER TABLE `information_process` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "lan_wan"
+-- Dumping data for table `lan_man`
 --
 
-LOCK TABLES "lan_wan" WRITE;
-/*!40000 ALTER TABLE "lan_wan" DISABLE KEYS */;
-INSERT INTO "lan_wan" ("wan_id", "lan_id") VALUES (1,1);
-/*!40000 ALTER TABLE "lan_wan" ENABLE KEYS */;
+LOCK TABLES `lan_man` WRITE;
+/*!40000 ALTER TABLE `lan_man` DISABLE KEYS */;
+INSERT INTO `lan_man` (`man_id`, `lan_id`) VALUES (1,1),(2,1),(2,2),(2,3);
+/*!40000 ALTER TABLE `lan_man` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "lans"
+-- Dumping data for table `lan_wan`
 --
 
-LOCK TABLES "lans" WRITE;
-/*!40000 ALTER TABLE "lans" DISABLE KEYS */;
-INSERT INTO "lans" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'LAN_1','Lan principal','2020-07-22 05:42:00','2020-07-22 05:42:00',NULL),(2,'LAN_2','Second LAN','2021-06-23 19:19:38','2021-06-23 19:19:38',NULL),(3,'LAN_0','Lan zero','2021-06-23 19:20:04','2021-06-23 19:20:04',NULL);
-/*!40000 ALTER TABLE "lans" ENABLE KEYS */;
+LOCK TABLES `lan_wan` WRITE;
+/*!40000 ALTER TABLE `lan_wan` DISABLE KEYS */;
+INSERT INTO `lan_wan` (`wan_id`, `lan_id`) VALUES (1,1);
+/*!40000 ALTER TABLE `lan_wan` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "logical_server_m_application"
+-- Dumping data for table `lans`
 --
 
-LOCK TABLES "logical_server_m_application" WRITE;
-/*!40000 ALTER TABLE "logical_server_m_application" DISABLE KEYS */;
-INSERT INTO "logical_server_m_application" ("m_application_id", "logical_server_id") VALUES (2,1),(2,2),(3,2),(1,1),(18,4),(15,3),(4,2),(4,5);
-/*!40000 ALTER TABLE "logical_server_m_application" ENABLE KEYS */;
+LOCK TABLES `lans` WRITE;
+/*!40000 ALTER TABLE `lans` DISABLE KEYS */;
+INSERT INTO `lans` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'LAN_1','Lan principal','2020-07-22 05:42:00','2020-07-22 05:42:00',NULL),(2,'LAN_2','Second LAN','2021-06-23 19:19:38','2021-06-23 19:19:38',NULL),(3,'LAN_0','Lan zero','2021-06-23 19:20:04','2021-06-23 19:20:04',NULL);
+/*!40000 ALTER TABLE `lans` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "logical_server_physical_server"
+-- Dumping data for table `logical_server_m_application`
 --
 
-LOCK TABLES "logical_server_physical_server" WRITE;
-/*!40000 ALTER TABLE "logical_server_physical_server" DISABLE KEYS */;
-INSERT INTO "logical_server_physical_server" ("logical_server_id", "physical_server_id") VALUES (2,1),(2,2),(1,1),(1,7),(3,8),(4,7),(5,8);
-/*!40000 ALTER TABLE "logical_server_physical_server" ENABLE KEYS */;
+LOCK TABLES `logical_server_m_application` WRITE;
+/*!40000 ALTER TABLE `logical_server_m_application` DISABLE KEYS */;
+INSERT INTO `logical_server_m_application` (`m_application_id`, `logical_server_id`) VALUES (2,1),(2,2),(3,2),(1,1),(18,4),(15,3),(4,2),(4,5);
+/*!40000 ALTER TABLE `logical_server_m_application` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "logical_servers"
+-- Dumping data for table `logical_server_physical_server`
 --
 
-LOCK TABLES "logical_servers" WRITE;
-/*!40000 ALTER TABLE "logical_servers" DISABLE KEYS */;
-INSERT INTO "logical_servers" ("id", "name", "description", "net_services", "configuration", "created_at", "updated_at", "deleted_at", "operating_system", "address_ip", "cpu", "memory", "environment", "disk", "install_date", "update_date") VALUES (1,'SRV-1','<p>Description du serveur 1</p>','DNS, HTTP, HTTPS','<p>Configuration du serveur 1</p>','2020-07-12 16:57:42','2021-08-17 13:13:21',NULL,'Windows 3.1','10.10.1.1, 10.10.10.1','2','8','PROD',60,NULL,NULL),(2,'SRV-2','<p>Description du serveur 2</p>','HTTPS, SSH','<p>Configuration par défaut</p>','2020-07-30 10:00:16','2021-08-17 18:17:41',NULL,'Windows 10','10.50.1.2','2','5','PROD',100,NULL,NULL),(3,'SRV-3','<p>Description du serveur 3</p>','HTTP, HTTPS',NULL,'2021-08-26 14:33:03','2021-08-26 14:33:38',NULL,'Ubuntu 20.04','10.70.8.3','4','16','PROD',80,NULL,NULL),(4,'SRV-42','<p><i>The Ultimate Question of Life, the Universe and Everything</i></p>',NULL,'<p>Full configuration</p>','2021-11-15 16:03:59','2022-03-20 11:39:54',NULL,'OS 42','10.0.0.42','42','42 G','PROD',42,NULL,NULL),(5,'SRV-4','<p>Description du serveur 4</p>',NULL,NULL,'2022-05-02 16:43:02','2022-05-02 16:49:34',NULL,'Ubunti 22.04 LTS','10.10.3.2','4','2','Dev',NULL,'2022-05-01 20:47:41','2022-05-02 20:47:47');
-/*!40000 ALTER TABLE "logical_servers" ENABLE KEYS */;
+LOCK TABLES `logical_server_physical_server` WRITE;
+/*!40000 ALTER TABLE `logical_server_physical_server` DISABLE KEYS */;
+INSERT INTO `logical_server_physical_server` (`logical_server_id`, `physical_server_id`) VALUES (2,1),(2,2),(1,1),(1,7),(3,8),(4,7),(5,8);
+/*!40000 ALTER TABLE `logical_server_physical_server` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "m_application_events"
+-- Dumping data for table `logical_servers`
 --
 
-LOCK TABLES "m_application_events" WRITE;
-/*!40000 ALTER TABLE "m_application_events" DISABLE KEYS */;
-/*!40000 ALTER TABLE "m_application_events" ENABLE KEYS */;
+LOCK TABLES `logical_servers` WRITE;
+/*!40000 ALTER TABLE `logical_servers` DISABLE KEYS */;
+INSERT INTO `logical_servers` (`id`, `name`, `description`, `net_services`, `configuration`, `created_at`, `updated_at`, `deleted_at`, `operating_system`, `address_ip`, `cpu`, `memory`, `environment`, `disk`, `install_date`, `update_date`) VALUES (1,'SRV-1','<p>Description du serveur 1</p>','DNS, HTTP, HTTPS','<p>Configuration du serveur 1</p>','2020-07-12 16:57:42','2021-08-17 13:13:21',NULL,'Windows 3.1','10.10.1.1, 10.10.10.1','2','8','PROD',60,NULL,NULL),(2,'SRV-2','<p>Description du serveur 2</p>','HTTPS, SSH','<p>Configuration par défaut</p>','2020-07-30 10:00:16','2021-08-17 18:17:41',NULL,'Windows 10','10.50.1.2','2','5','PROD',100,NULL,NULL),(3,'SRV-3','<p>Description du serveur 3</p>','HTTP, HTTPS',NULL,'2021-08-26 14:33:03','2021-08-26 14:33:38',NULL,'Ubuntu 20.04','10.70.8.3','4','16','PROD',80,NULL,NULL),(4,'SRV-42','<p><i>The Ultimate Question of Life, the Universe and Everything</i></p>',NULL,'<p>Full configuration</p>','2021-11-15 16:03:59','2022-03-20 11:39:54',NULL,'OS 42','10.0.0.42','42','42 G','PROD',42,NULL,NULL),(5,'SRV-4','<p>Description du serveur 4</p>',NULL,NULL,'2022-05-02 16:43:02','2022-05-02 16:49:34',NULL,'Ubunti 22.04 LTS','10.10.3.2','4','2','Dev',NULL,'2022-05-01 20:47:41','2022-05-02 20:47:47');
+/*!40000 ALTER TABLE `logical_servers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "m_application_process"
+-- Dumping data for table `m_application_events`
 --
 
-LOCK TABLES "m_application_process" WRITE;
-/*!40000 ALTER TABLE "m_application_process" DISABLE KEYS */;
-INSERT INTO "m_application_process" ("m_application_id", "process_id") VALUES (2,1),(2,2),(3,2),(1,1),(14,2),(4,3),(12,4),(16,1),(16,2),(16,3),(16,4),(16,9);
-/*!40000 ALTER TABLE "m_application_process" ENABLE KEYS */;
+LOCK TABLES `m_application_events` WRITE;
+/*!40000 ALTER TABLE `m_application_events` DISABLE KEYS */;
+/*!40000 ALTER TABLE `m_application_events` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "m_applications"
+-- Dumping data for table `m_application_process`
 --
 
-LOCK TABLES "m_applications" WRITE;
-/*!40000 ALTER TABLE "m_applications" DISABLE KEYS */;
-INSERT INTO "m_applications" ("id", "name", "description", "security_need_c", "responsible", "functional_referent", "type", "technology", "external", "users", "editor", "created_at", "updated_at", "deleted_at", "entity_resp_id", "application_block_id", "documentation", "security_need_i", "security_need_a", "security_need_t", "version", "install_date", "update_date") VALUES (1,'Application 1','<p>Description de l\'application 1</p>',1,'RSSI',NULL,'logiciel','Microsoft',NULL,'> 20',NULL,'2020-06-14 09:20:15','2022-03-20 17:53:29',NULL,2,3,'//Documentation/application1.docx',1,1,1,'1.2',NULL,NULL),(2,'Application 2','<p><i>Description</i> de l\'<strong>application</strong> 2</p>',2,'RSSI',NULL,'progiciel','martian','SaaS','>100',NULL,'2020-06-14 09:31:16','2022-02-06 15:52:36',NULL,18,1,'None',2,2,2,'1.0',NULL,NULL),(3,'Application 3','<p>Test application 3</p>',1,'RSSI',NULL,'progiciel','Microsoft','Interne','>100',NULL,'2020-06-17 17:33:41','2021-05-15 08:06:53',NULL,12,2,'Aucune',2,3,3,NULL,NULL,NULL),(4,'Application 4','<p>Description app4</p>',2,'RSSI',NULL,'logiciel','Microsoft','Internl','>100',NULL,'2020-08-11 14:13:02','2021-07-11 08:59:57',NULL,1,2,'None',2,3,2,NULL,NULL,NULL),(5,'CUST AP01','<p>Customer appication</p>',0,NULL,NULL,NULL,'web',NULL,NULL,NULL,'2020-08-22 04:58:18','2020-08-26 14:56:20','2020-08-26 14:56:20',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(6,'totototo',NULL,0,NULL,NULL,NULL,'totottoo',NULL,NULL,NULL,'2020-08-22 04:59:26','2020-08-22 04:59:43','2020-08-22 04:59:43',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(7,'Windows Word','<p>Description de l\'application</p>',3,'Nestor',NULL,'artificiel','client lourd',NULL,'>100',NULL,'2020-08-23 08:20:34','2020-08-26 14:56:23','2020-08-26 14:56:23',10,2,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(8,'Application 99',NULL,1,'André',NULL,'progiciel','client lourd','SaaS','>100',NULL,'2020-08-23 10:08:02','2020-08-26 14:56:13','2020-08-26 14:56:13',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(9,'Test33','<p>fsfsdfsd</p>',0,'Nestor',NULL,'progiciel','martian',NULL,NULL,NULL,'2020-08-26 14:54:05','2020-08-26 14:54:35','2020-08-26 14:54:35',10,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(10,'Test33R','<p>fsfsdfsd</p>',0,'Nestor',NULL,'progiciel','martian',NULL,NULL,NULL,'2020-08-26 14:54:28','2020-08-26 14:54:39','2020-08-26 14:54:39',10,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(11,'SuperApp','<p>Supper application</p>',0,'RSSI',NULL,'logiciel','martian',NULL,NULL,NULL,'2021-04-12 14:54:57','2021-04-12 17:10:44','2021-04-12 17:10:44',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(12,'SuperApp','<p>Super super application !</p>',1,'RSSI',NULL,'Web','Oracle','Interne',NULL,NULL,'2021-04-12 17:10:59','2021-06-23 19:33:15',NULL,1,2,NULL,1,1,1,NULL,NULL,NULL),(13,'test application',NULL,0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2021-05-07 08:23:59','2021-05-07 08:24:03','2021-05-07 08:24:03',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(14,'Windows Calc','<p>Calculatrice windows</p>',2,'RSSI',NULL,'logiciel','Microsoft','Internl',NULL,NULL,'2021-05-13 08:15:27','2022-03-20 17:53:29',NULL,1,3,NULL,0,0,0,NULL,NULL,NULL),(15,'Compta','<p>Application de comptabilité</p>',3,'RSSI',NULL,'progiciel','Microsoft','Interne','>100',NULL,'2021-05-15 07:53:15','2021-05-15 07:53:15',NULL,1,2,NULL,4,2,3,NULL,NULL,NULL),(16,'Queue Manager','<p>Queue manager</p>',4,'RSSI',NULL,'logiciel','Internal Dev','Interne','>100',NULL,'2021-08-02 15:17:11','2021-08-02 15:18:32',NULL,1,1,'//Portal/QueueManager.doc',4,4,4,NULL,NULL,NULL),(17,'test',NULL,0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2021-10-10 11:03:24','2021-10-10 11:03:24',NULL,NULL,NULL,NULL,0,0,0,NULL,NULL,NULL),(18,'Application 42','<p>The Ultimate Question of Life, the Universe and Everything</p>',-1,'Nestor',NULL,NULL,NULL,NULL,NULL,NULL,'2021-11-15 16:03:20','2021-12-11 10:06:18',NULL,NULL,NULL,NULL,-1,-1,0,NULL,NULL,NULL);
-/*!40000 ALTER TABLE "m_applications" ENABLE KEYS */;
+LOCK TABLES `m_application_process` WRITE;
+/*!40000 ALTER TABLE `m_application_process` DISABLE KEYS */;
+INSERT INTO `m_application_process` (`m_application_id`, `process_id`) VALUES (2,1),(2,2),(3,2),(1,1),(14,2),(4,3),(12,4),(16,1),(16,2),(16,3),(16,4),(16,9);
+/*!40000 ALTER TABLE `m_application_process` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "macro_processuses"
+-- Dumping data for table `m_applications`
 --
 
-LOCK TABLES "macro_processuses" WRITE;
-/*!40000 ALTER TABLE "macro_processuses" DISABLE KEYS */;
-INSERT INTO "macro_processuses" ("id", "name", "description", "io_elements", "security_need_c", "owner", "created_at", "updated_at", "deleted_at", "security_need_i", "security_need_a", "security_need_t") VALUES (1,'Macro-Processus 1','<p>Description du macro-processus de test.</p>','<p>Entrant :</p><ul><li>donnée 1</li><li>donnée 2</li><li>donnée 3</li></ul><p>Sortant :</p><ul><li>donnée 4</li><li>donnée 5</li></ul>',4,'Nestor','2020-06-10 07:02:16','2021-05-14 13:29:36',NULL,3,2,1),(2,'Macro-Processus 2','<p>Description du macro-processus</p>','<p>Valeur de test</p>',1,'Simon','2020-06-13 01:03:42','2021-05-14 07:21:10',NULL,2,3,4),(3,'Valeur de test','<p>Valeur de test</p>','<p>Valeur de test</p>',3,'All','2020-08-09 05:32:37','2020-08-24 14:45:57','2020-08-24 14:45:57',NULL,NULL,NULL),(4,'Proc3','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:13:55','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(5,'Proc4','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:19:32','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(6,'Proc5','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:29:20','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(7,'MP1','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:31:40','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(8,'MP2','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:37:39','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(9,'MP3','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:38:06','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(10,'Macro-Processus 3','<p>Description du troisième macro-processus</p>','<ul><li>un</li><li>deux</li><li>trois</li><li>quatre</li></ul>',2,'Nestor','2020-11-24 08:21:38','2021-05-14 07:20:55',NULL,2,2,2),(11,'Macro-Processus 4','<p>Description du macro processus quatre</p>','<ul><li>crayon</li><li>stylos</li><li>gommes</li></ul>',1,'Pirre','2021-05-14 07:19:51','2021-09-22 11:00:08','2021-09-22 11:00:08',1,1,1);
-/*!40000 ALTER TABLE "macro_processuses" ENABLE KEYS */;
+LOCK TABLES `m_applications` WRITE;
+/*!40000 ALTER TABLE `m_applications` DISABLE KEYS */;
+INSERT INTO `m_applications` (`id`, `name`, `description`, `security_need_c`, `responsible`, `functional_referent`, `type`, `technology`, `external`, `users`, `editor`, `created_at`, `updated_at`, `deleted_at`, `entity_resp_id`, `application_block_id`, `documentation`, `security_need_i`, `security_need_a`, `security_need_t`, `version`, `install_date`, `update_date`) VALUES (1,'Application 1','<p>Description de l\'application 1</p>',1,'RSSI',NULL,'logiciel','Microsoft',NULL,'> 20',NULL,'2020-06-14 09:20:15','2022-03-20 17:53:29',NULL,2,3,'//Documentation/application1.docx',1,1,1,'1.2',NULL,NULL),(2,'Application 2','<p><i>Description</i> de l\'<strong>application</strong> 2</p>',2,'RSSI',NULL,'progiciel','martian','SaaS','>100',NULL,'2020-06-14 09:31:16','2022-02-06 15:52:36',NULL,18,1,'None',2,2,2,'1.0',NULL,NULL),(3,'Application 3','<p>Test application 3</p>',1,'RSSI',NULL,'progiciel','Microsoft','Interne','>100',NULL,'2020-06-17 17:33:41','2021-05-15 08:06:53',NULL,12,2,'Aucune',2,3,3,NULL,NULL,NULL),(4,'Application 4','<p>Description app4</p>',2,'RSSI',NULL,'logiciel','Microsoft','Internl','>100',NULL,'2020-08-11 14:13:02','2021-07-11 08:59:57',NULL,1,2,'None',2,3,2,NULL,NULL,NULL),(5,'CUST AP01','<p>Customer appication</p>',0,NULL,NULL,NULL,'web',NULL,NULL,NULL,'2020-08-22 04:58:18','2020-08-26 14:56:20','2020-08-26 14:56:20',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(6,'totototo',NULL,0,NULL,NULL,NULL,'totottoo',NULL,NULL,NULL,'2020-08-22 04:59:26','2020-08-22 04:59:43','2020-08-22 04:59:43',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(7,'Windows Word','<p>Description de l\'application</p>',3,'Nestor',NULL,'artificiel','client lourd',NULL,'>100',NULL,'2020-08-23 08:20:34','2020-08-26 14:56:23','2020-08-26 14:56:23',10,2,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(8,'Application 99',NULL,1,'André',NULL,'progiciel','client lourd','SaaS','>100',NULL,'2020-08-23 10:08:02','2020-08-26 14:56:13','2020-08-26 14:56:13',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(9,'Test33','<p>fsfsdfsd</p>',0,'Nestor',NULL,'progiciel','martian',NULL,NULL,NULL,'2020-08-26 14:54:05','2020-08-26 14:54:35','2020-08-26 14:54:35',10,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(10,'Test33R','<p>fsfsdfsd</p>',0,'Nestor',NULL,'progiciel','martian',NULL,NULL,NULL,'2020-08-26 14:54:28','2020-08-26 14:54:39','2020-08-26 14:54:39',10,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(11,'SuperApp','<p>Supper application</p>',0,'RSSI',NULL,'logiciel','martian',NULL,NULL,NULL,'2021-04-12 14:54:57','2021-04-12 17:10:44','2021-04-12 17:10:44',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(12,'SuperApp','<p>Super super application !</p>',1,'RSSI',NULL,'Web','Oracle','Interne',NULL,NULL,'2021-04-12 17:10:59','2021-06-23 19:33:15',NULL,1,2,NULL,1,1,1,NULL,NULL,NULL),(13,'test application',NULL,0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2021-05-07 08:23:59','2021-05-07 08:24:03','2021-05-07 08:24:03',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),(14,'Windows Calc','<p>Calculatrice windows</p>',2,'RSSI',NULL,'logiciel','Microsoft','Internl',NULL,NULL,'2021-05-13 08:15:27','2022-03-20 17:53:29',NULL,1,3,NULL,0,0,0,NULL,NULL,NULL),(15,'Compta','<p>Application de comptabilité</p>',3,'RSSI',NULL,'progiciel','Microsoft','Interne','>100',NULL,'2021-05-15 07:53:15','2021-05-15 07:53:15',NULL,1,2,NULL,4,2,3,NULL,NULL,NULL),(16,'Queue Manager','<p>Queue manager</p>',4,'RSSI',NULL,'logiciel','Internal Dev','Interne','>100',NULL,'2021-08-02 15:17:11','2021-08-02 15:18:32',NULL,1,1,'//Portal/QueueManager.doc',4,4,4,NULL,NULL,NULL),(17,'test',NULL,0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2021-10-10 11:03:24','2021-10-10 11:03:24',NULL,NULL,NULL,NULL,0,0,0,NULL,NULL,NULL),(18,'Application 42','<p>The Ultimate Question of Life, the Universe and Everything</p>',-1,'Nestor',NULL,NULL,NULL,NULL,NULL,NULL,'2021-11-15 16:03:20','2021-12-11 10:06:18',NULL,NULL,NULL,NULL,-1,-1,0,NULL,NULL,NULL);
+/*!40000 ALTER TABLE `m_applications` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "man_wan"
+-- Dumping data for table `macro_processuses`
 --
 
-LOCK TABLES "man_wan" WRITE;
-/*!40000 ALTER TABLE "man_wan" DISABLE KEYS */;
-INSERT INTO "man_wan" ("wan_id", "man_id") VALUES (1,1);
-/*!40000 ALTER TABLE "man_wan" ENABLE KEYS */;
+LOCK TABLES `macro_processuses` WRITE;
+/*!40000 ALTER TABLE `macro_processuses` DISABLE KEYS */;
+INSERT INTO `macro_processuses` (`id`, `name`, `description`, `io_elements`, `security_need_c`, `owner`, `created_at`, `updated_at`, `deleted_at`, `security_need_i`, `security_need_a`, `security_need_t`) VALUES (1,'Macro-Processus 1','<p>Description du macro-processus de test.</p>','<p>Entrant :</p><ul><li>donnée 1</li><li>donnée 2</li><li>donnée 3</li></ul><p>Sortant :</p><ul><li>donnée 4</li><li>donnée 5</li></ul>',4,'Nestor','2020-06-10 07:02:16','2021-05-14 13:29:36',NULL,3,2,1),(2,'Macro-Processus 2','<p>Description du macro-processus</p>','<p>Valeur de test</p>',1,'Simon','2020-06-13 01:03:42','2021-05-14 07:21:10',NULL,2,3,4),(3,'Valeur de test','<p>Valeur de test</p>','<p>Valeur de test</p>',3,'All','2020-08-09 05:32:37','2020-08-24 14:45:57','2020-08-24 14:45:57',NULL,NULL,NULL),(4,'Proc3','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:13:55','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(5,'Proc4','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:19:32','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(6,'Proc5','<p>dfsdf</p>','<p>dsfsdf</p>',0,NULL,'2020-08-31 14:29:20','2020-08-31 14:31:29','2020-08-31 14:31:29',NULL,NULL,NULL),(7,'MP1','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:31:40','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(8,'MP2','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:37:39','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(9,'MP3','<p>sdfsdfs</p>',NULL,0,NULL,'2020-08-31 14:38:06','2020-08-31 14:38:31','2020-08-31 14:38:31',NULL,NULL,NULL),(10,'Macro-Processus 3','<p>Description du troisième macro-processus</p>','<ul><li>un</li><li>deux</li><li>trois</li><li>quatre</li></ul>',2,'Nestor','2020-11-24 08:21:38','2021-05-14 07:20:55',NULL,2,2,2),(11,'Macro-Processus 4','<p>Description du macro processus quatre</p>','<ul><li>crayon</li><li>stylos</li><li>gommes</li></ul>',1,'Pirre','2021-05-14 07:19:51','2021-09-22 11:00:08','2021-09-22 11:00:08',1,1,1);
+/*!40000 ALTER TABLE `macro_processuses` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "mans"
+-- Dumping data for table `man_wan`
 --
 
-LOCK TABLES "mans" WRITE;
-/*!40000 ALTER TABLE "mans" DISABLE KEYS */;
-INSERT INTO "mans" ("id", "name", "created_at", "updated_at", "deleted_at") VALUES (1,'MAN_1','2020-08-22 04:17:20','2020-08-22 04:17:20',NULL),(2,'MAN_2','2021-05-07 08:14:27','2021-05-07 08:23:23',NULL),(3,'Test1','2022-04-25 12:43:02','2022-04-25 12:52:49','2022-04-25 12:52:49'),(4,'Test2','2022-04-25 12:43:09','2022-04-25 12:52:49','2022-04-25 12:52:49');
-/*!40000 ALTER TABLE "mans" ENABLE KEYS */;
+LOCK TABLES `man_wan` WRITE;
+/*!40000 ALTER TABLE `man_wan` DISABLE KEYS */;
+INSERT INTO `man_wan` (`wan_id`, `man_id`) VALUES (1,1);
+/*!40000 ALTER TABLE `man_wan` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "media"
+-- Dumping data for table `mans`
 --
 
-LOCK TABLES "media" WRITE;
-/*!40000 ALTER TABLE "media" DISABLE KEYS */;
-/*!40000 ALTER TABLE "media" ENABLE KEYS */;
+LOCK TABLES `mans` WRITE;
+/*!40000 ALTER TABLE `mans` DISABLE KEYS */;
+INSERT INTO `mans` (`id`, `name`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'MAN_1','2020-08-22 04:17:20','2020-08-22 04:17:20',NULL),(2,'MAN_2','2021-05-07 08:14:27','2021-05-07 08:23:23',NULL),(3,'Test1','2022-04-25 12:43:02','2022-04-25 12:52:49','2022-04-25 12:52:49'),(4,'Test2','2022-04-25 12:43:09','2022-04-25 12:52:49','2022-04-25 12:52:49');
+/*!40000 ALTER TABLE `mans` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "network_switches"
+-- Dumping data for table `media`
 --
 
-LOCK TABLES "network_switches" WRITE;
-/*!40000 ALTER TABLE "network_switches" DISABLE KEYS */;
-INSERT INTO "network_switches" ("id", "name", "ip", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Switch de test','123.4.5.6','<p>Test</p>','2020-07-13 17:30:37','2020-07-13 17:30:37',NULL),(2,'Second switch','10.1.1.1','<p>Second commutateur de test</p>','2022-04-25 12:55:44','2022-04-25 12:55:44',NULL);
-/*!40000 ALTER TABLE "network_switches" ENABLE KEYS */;
+LOCK TABLES `media` WRITE;
+/*!40000 ALTER TABLE `media` DISABLE KEYS */;
+/*!40000 ALTER TABLE `media` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "networks"
+-- Dumping data for table `network_switches`
 --
 
-LOCK TABLES "networks" WRITE;
-/*!40000 ALTER TABLE "networks" DISABLE KEYS */;
-INSERT INTO "networks" ("id", "name", "protocol_type", "responsible", "responsible_sec", "security_need_c", "description", "created_at", "updated_at", "deleted_at", "security_need_i", "security_need_a", "security_need_t") VALUES (1,'Réseau 1','TCP','Pierre','Paul',1,'<p>Description du réseau 1</p>','2020-06-23 12:34:14','2021-09-22 10:20:11',NULL,2,3,4),(2,'Réseau 2','TCP','Johan','Jean-Marc',1,'<p>Description du réseau 2</p>','2020-07-01 15:45:41','2021-09-22 10:21:23',NULL,1,1,1),(3,'test',NULL,NULL,NULL,4,'<p>réseau test</p>','2021-09-22 10:30:23','2021-09-22 10:30:29','2021-09-22 10:30:29',4,4,4);
-/*!40000 ALTER TABLE "networks" ENABLE KEYS */;
+LOCK TABLES `network_switches` WRITE;
+/*!40000 ALTER TABLE `network_switches` DISABLE KEYS */;
+INSERT INTO `network_switches` (`id`, `name`, `ip`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Switch de test','123.4.5.6','<p>Test</p>','2020-07-13 17:30:37','2020-07-13 17:30:37',NULL),(2,'Second switch','10.1.1.1','<p>Second commutateur de test</p>','2022-04-25 12:55:44','2022-04-25 12:55:44',NULL);
+/*!40000 ALTER TABLE `network_switches` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "operation_task"
+-- Dumping data for table `networks`
 --
 
-LOCK TABLES "operation_task" WRITE;
-/*!40000 ALTER TABLE "operation_task" DISABLE KEYS */;
-INSERT INTO "operation_task" ("operation_id", "task_id") VALUES (1,1),(1,2),(2,1),(3,3),(4,2),(5,1),(5,2),(5,3);
-/*!40000 ALTER TABLE "operation_task" ENABLE KEYS */;
+LOCK TABLES `networks` WRITE;
+/*!40000 ALTER TABLE `networks` DISABLE KEYS */;
+INSERT INTO `networks` (`id`, `name`, `protocol_type`, `responsible`, `responsible_sec`, `security_need_c`, `description`, `created_at`, `updated_at`, `deleted_at`, `security_need_i`, `security_need_a`, `security_need_t`) VALUES (1,'Réseau 1','TCP','Pierre','Paul',1,'<p>Description du réseau 1</p>','2020-06-23 12:34:14','2021-09-22 10:20:11',NULL,2,3,4),(2,'Réseau 2','TCP','Johan','Jean-Marc',1,'<p>Description du réseau 2</p>','2020-07-01 15:45:41','2021-09-22 10:21:23',NULL,1,1,1),(3,'test',NULL,NULL,NULL,4,'<p>réseau test</p>','2021-09-22 10:30:23','2021-09-22 10:30:29','2021-09-22 10:30:29',4,4,4);
+/*!40000 ALTER TABLE `networks` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "operations"
+-- Dumping data for table `oauth_access_tokens`
 --
 
-LOCK TABLES "operations" WRITE;
-/*!40000 ALTER TABLE "operations" DISABLE KEYS */;
-INSERT INTO "operations" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Operation 1','<p>Description de l\'opération</p>','2020-06-13 00:02:42','2020-06-13 00:02:42',NULL),(2,'Operation 2','<p>Description de l\'opération</p>','2020-06-13 00:02:58','2020-06-13 00:02:58',NULL),(3,'Operation 3','<p>Desciption de l\'opération</p>','2020-06-13 00:03:11','2020-07-15 14:34:52',NULL),(4,'Operation 4',NULL,'2020-07-15 14:34:02','2020-07-15 14:34:02',NULL),(5,'Master operation','<p>Opération maitre</p>','2020-08-15 04:01:40','2020-08-15 04:01:40',NULL);
-/*!40000 ALTER TABLE "operations" ENABLE KEYS */;
+LOCK TABLES `oauth_access_tokens` WRITE;
+/*!40000 ALTER TABLE `oauth_access_tokens` DISABLE KEYS */;
+/*!40000 ALTER TABLE `oauth_access_tokens` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "peripherals"
+-- Dumping data for table `oauth_auth_codes`
 --
 
-LOCK TABLES "peripherals" WRITE;
-/*!40000 ALTER TABLE "peripherals" DISABLE KEYS */;
-INSERT INTO "peripherals" ("id", "name", "type", "description", "responsible", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id") VALUES (1,'PER_01','IBM 3400','<p>important peripheral</p>','Marcel','2020-07-25 06:18:40','2020-07-25 06:19:46',NULL,1,2,NULL),(2,'PER_02','IBM 5600','<p>Description</p>','Nestor','2020-07-25 06:19:18','2020-07-25 06:19:18',NULL,3,5,NULL),(3,'PER_03','HAL 8100','<p>Space device</p>','Niel','2020-07-25 06:19:58','2020-07-25 06:20:18',NULL,3,4,NULL);
-/*!40000 ALTER TABLE "peripherals" ENABLE KEYS */;
+LOCK TABLES `oauth_auth_codes` WRITE;
+/*!40000 ALTER TABLE `oauth_auth_codes` DISABLE KEYS */;
+/*!40000 ALTER TABLE `oauth_auth_codes` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "phones"
+-- Dumping data for table `oauth_clients`
 --
 
-LOCK TABLES "phones" WRITE;
-/*!40000 ALTER TABLE "phones" DISABLE KEYS */;
-INSERT INTO "phones" ("id", "name", "description", "type", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "physical_switch_id") VALUES (1,'Phone 01','<p>Téléphone de test</p>','MOTOROAL 3110','2020-07-21 05:16:46','2020-07-25 07:15:17',NULL,1,1,NULL),(2,'Phone 03','<p>Special AA phone</p>','Top secret red phne','2020-07-21 05:18:01','2020-07-25 07:25:38',NULL,2,4,NULL),(3,'Phone 02','<p>Description phone 02</p>','IPhone 2','2020-07-25 06:52:23','2020-07-25 07:25:19',NULL,2,3,NULL);
-/*!40000 ALTER TABLE "phones" ENABLE KEYS */;
+LOCK TABLES `oauth_clients` WRITE;
+/*!40000 ALTER TABLE `oauth_clients` DISABLE KEYS */;
+/*!40000 ALTER TABLE `oauth_clients` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "physical_router_vlan"
+-- Dumping data for table `oauth_personal_access_clients`
 --
 
-LOCK TABLES "physical_router_vlan" WRITE;
-/*!40000 ALTER TABLE "physical_router_vlan" DISABLE KEYS */;
-INSERT INTO "physical_router_vlan" ("physical_router_id", "vlan_id") VALUES (1,1),(1,3),(2,3);
-/*!40000 ALTER TABLE "physical_router_vlan" ENABLE KEYS */;
+LOCK TABLES `oauth_personal_access_clients` WRITE;
+/*!40000 ALTER TABLE `oauth_personal_access_clients` DISABLE KEYS */;
+/*!40000 ALTER TABLE `oauth_personal_access_clients` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "physical_routers"
+-- Dumping data for table `oauth_refresh_tokens`
 --
 
-LOCK TABLES "physical_routers" WRITE;
-/*!40000 ALTER TABLE "physical_routers" DISABLE KEYS */;
-INSERT INTO "physical_routers" ("id", "description", "type", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id", "name") VALUES (1,'<p>Routeur prncipal</p>','Fortinet','2020-07-10 06:58:53','2021-10-12 19:08:21',NULL,1,1,1,'R1'),(2,'<p>Routeur secondaire</p>','CISCO','2020-07-10 07:19:11','2020-07-25 08:28:17',NULL,2,3,5,'R2');
-/*!40000 ALTER TABLE "physical_routers" ENABLE KEYS */;
+LOCK TABLES `oauth_refresh_tokens` WRITE;
+/*!40000 ALTER TABLE `oauth_refresh_tokens` DISABLE KEYS */;
+/*!40000 ALTER TABLE `oauth_refresh_tokens` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "physical_security_devices"
+-- Dumping data for table `operation_task`
 --
 
-LOCK TABLES "physical_security_devices" WRITE;
-/*!40000 ALTER TABLE "physical_security_devices" DISABLE KEYS */;
-INSERT INTO "physical_security_devices" ("id", "name", "type", "description", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id") VALUES (1,'Magic Gate','Gate','<p>BIG Magic Gate</p>','2021-05-20 14:40:43','2021-11-13 20:29:45',NULL,1,1,1),(2,'Magic Firewall','Firewall','<p>The magic firewall - PT3743</p>','2021-06-07 14:56:26','2021-11-13 20:29:32',NULL,2,3,5),(3,'Sensor-1','Sensor','<p>Temperature sensor</p>','2021-11-13 20:37:14','2021-11-13 20:37:56',NULL,1,3,NULL);
-/*!40000 ALTER TABLE "physical_security_devices" ENABLE KEYS */;
+LOCK TABLES `operation_task` WRITE;
+/*!40000 ALTER TABLE `operation_task` DISABLE KEYS */;
+INSERT INTO `operation_task` (`operation_id`, `task_id`) VALUES (1,1),(1,2),(2,1),(3,3),(4,2),(5,1),(5,2),(5,3);
+/*!40000 ALTER TABLE `operation_task` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "physical_servers"
+-- Dumping data for table `operations`
 --
 
-LOCK TABLES "physical_servers" WRITE;
-/*!40000 ALTER TABLE "physical_servers" DISABLE KEYS */;
-INSERT INTO "physical_servers" ("id", "name", "description", "responsible", "configuration", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id", "physical_switch_id", "type") VALUES (1,'Serveur A1','<p>Description du serveur A1</p>','Marc','<p>OS: OS2<br>IP : 127.0.0.1<br>&nbsp;</p>','2020-06-21 05:27:02','2021-11-27 11:12:00',NULL,1,2,4,NULL,'System 840'),(2,'Serveur A2','<p>Description du serveur A2</p>','Marc','<p>Configuration du serveur A<br>OS : Linux 23.4<br>RAM: 32G</p>','2020-06-21 05:27:58','2021-11-27 11:12:12',NULL,3,5,6,NULL,'System 840'),(3,'Serveur A3','<p>Serveur mobile</p>','Marc','<p>None</p>','2020-07-14 15:30:48','2021-11-27 11:12:24',NULL,1,1,3,NULL,'System 840'),(4,'ZZ99','<p>Zoro server</p>',NULL,NULL,'2020-07-14 15:37:50','2020-08-25 14:54:58','2020-08-25 14:54:58',3,5,NULL,NULL,NULL),(5,'K01','<p>Serveur K01</p>',NULL,'<p>TOP CPU<br>TOP RAM</p>','2020-07-15 14:37:04','2020-08-29 12:08:09','2020-08-29 12:08:09',1,1,3,NULL,NULL),(6,'Mainframe 01','<p>Central accounting system</p>','Marc','<p>40G RAM<br>360P Disk<br>CICS / Cobol</p>','2020-09-05 08:02:49','2021-11-27 11:11:43',NULL,1,1,1,2,'Type 404'),(7,'Mainframe T1','<p>Mainframe de test</p>','Marc','<p>IDEM prod</p>','2020-09-05 08:22:18','2021-11-27 11:11:01',NULL,2,3,4,2,'HAL 340'),(8,'Serveur A4','<p>Departmental server</p>','Marc','<p>Standard configuration</p>','2021-06-22 15:34:33','2021-11-27 11:12:50',NULL,2,3,5,NULL,'Mini 900/2');
-/*!40000 ALTER TABLE "physical_servers" ENABLE KEYS */;
+LOCK TABLES `operations` WRITE;
+/*!40000 ALTER TABLE `operations` DISABLE KEYS */;
+INSERT INTO `operations` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Operation 1','<p>Description de l\'opération</p>','2020-06-13 00:02:42','2020-06-13 00:02:42',NULL),(2,'Operation 2','<p>Description de l\'opération</p>','2020-06-13 00:02:58','2020-06-13 00:02:58',NULL),(3,'Operation 3','<p>Desciption de l\'opération</p>','2020-06-13 00:03:11','2020-07-15 14:34:52',NULL),(4,'Operation 4',NULL,'2020-07-15 14:34:02','2020-07-15 14:34:02',NULL),(5,'Master operation','<p>Opération maitre</p>','2020-08-15 04:01:40','2020-08-15 04:01:40',NULL);
+/*!40000 ALTER TABLE `operations` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "physical_switches"
+-- Dumping data for table `password_resets`
 --
 
-LOCK TABLES "physical_switches" WRITE;
-/*!40000 ALTER TABLE "physical_switches" DISABLE KEYS */;
-INSERT INTO "physical_switches" ("id", "name", "description", "type", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id") VALUES (1,'Switch de test','<p>Master test switch.</p>','Nortel A39','2020-07-17 13:29:09','2022-04-25 16:22:02',NULL,1,2,4),(2,'Switch 2','<p>Description switch 2</p>','Alcatel 430','2020-07-17 13:31:41','2020-07-17 13:31:41',NULL,1,1,1),(3,'Switch 1','<p>Desription du premier switch.</p>','Nortel 2300','2020-07-25 05:27:27','2022-04-25 12:55:06',NULL,2,3,5),(4,'Switch 3','<p>Desciption du switch 3</p>','Alcatel 3500','2020-07-25 07:42:51','2020-07-25 07:43:21',NULL,3,5,6),(5,'AB','<p>Test 2 chars switch</p>',NULL,'2020-08-22 04:19:45','2020-08-27 16:04:20','2020-08-27 16:04:20',NULL,NULL,NULL);
-/*!40000 ALTER TABLE "physical_switches" ENABLE KEYS */;
+LOCK TABLES `password_resets` WRITE;
+/*!40000 ALTER TABLE `password_resets` DISABLE KEYS */;
+/*!40000 ALTER TABLE `password_resets` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "processes"
+-- Dumping data for table `peripherals`
 --
 
-LOCK TABLES "processes" WRITE;
-/*!40000 ALTER TABLE "processes" DISABLE KEYS */;
-INSERT INTO "processes" ("id", "identifiant", "description", "owner", "security_need_c", "in_out", "dummy", "created_at", "updated_at", "deleted_at", "macroprocess_id", "security_need_i", "security_need_a", "security_need_t") VALUES (1,'Processus 1','<p>Description du processus 1</p>','Ched',3,'<ul><li>pommes</li><li>poires</li><li>cerise</li></ul><p>&lt;test</p>',NULL,'2020-06-17 14:36:24','2021-09-22 11:38:57',NULL,1,2,3,1),(2,'Processus 2','<p>Description du processus 2</p>','Ched',3,'<p>1 2 3 4 5 6</p>',NULL,'2020-06-17 14:36:58','2021-09-22 10:59:14',NULL,10,4,2,4),(3,'Processus 3','<p>Description du processus 3</p>','Johan',3,'<p>a,b,c</p><p>d,e,f</p>',NULL,'2020-07-01 15:50:27','2021-08-17 08:22:13',NULL,2,2,3,1),(4,'Processus 4','<p>Description du processus 4</p>','Paul',4,'<ul><li>chaussettes</li><li>pantalon</li><li>chaussures</li></ul>',NULL,'2020-08-18 15:00:36','2021-08-17 08:22:29',NULL,2,2,2,2),(5,'totoat','<p>tto</p>',NULL,1,'<p>sgksdùmfk</p>',NULL,'2020-08-27 13:16:56','2020-08-27 13:17:01','2020-08-27 13:17:01',1,NULL,NULL,NULL),(6,'ptest','<p>description de ptest</p>',NULL,0,'<p>toto titi tutu</p>',NULL,'2020-08-29 11:10:23','2020-08-29 11:10:28','2020-08-29 11:10:28',NULL,NULL,NULL,NULL),(7,'ptest2','<p>fdfsdfsdf</p>',NULL,1,'<p>fdfsdfsd</p>',NULL,'2020-08-29 11:16:42','2020-08-29 11:17:09','2020-08-29 11:17:09',1,NULL,NULL,NULL),(8,'ptest3','<p>processus de test 3</p>','CHEM - Facturation',3,'<p>dsfsdf sdf sdf sd fsd fsd f s</p>',NULL,'2020-08-29 11:19:13','2020-08-29 11:20:59','2020-08-29 11:20:59',1,NULL,NULL,NULL),(9,'Processus 5','<p>Description du cinquième processus</p>','Paul',4,'<ul><li>chat</li><li>chien</li><li>poisson</li></ul>',NULL,'2021-05-14 07:10:02','2021-09-22 10:59:14',NULL,10,3,2,3),(10,'Proc 6',NULL,NULL,0,NULL,NULL,'2021-10-08 19:18:28','2021-10-08 19:28:38','2021-10-08 19:28:38',NULL,0,0,0);
-/*!40000 ALTER TABLE "processes" ENABLE KEYS */;
+LOCK TABLES `peripherals` WRITE;
+/*!40000 ALTER TABLE `peripherals` DISABLE KEYS */;
+INSERT INTO `peripherals` (`id`, `name`, `type`, `description`, `responsible`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`) VALUES (1,'PER_01','IBM 3400','<p>important peripheral</p>','Marcel','2020-07-25 06:18:40','2020-07-25 06:19:46',NULL,1,2,NULL),(2,'PER_02','IBM 5600','<p>Description</p>','Nestor','2020-07-25 06:19:18','2020-07-25 06:19:18',NULL,3,5,NULL),(3,'PER_03','HAL 8100','<p>Space device</p>','Niel','2020-07-25 06:19:58','2020-07-25 06:20:18',NULL,3,4,NULL);
+/*!40000 ALTER TABLE `peripherals` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "relations"
+-- Dumping data for table `phones`
 --
 
-LOCK TABLES "relations" WRITE;
-/*!40000 ALTER TABLE "relations" DISABLE KEYS */;
-INSERT INTO "relations" ("id", "importance", "name", "type", "description", "created_at", "updated_at", "deleted_at", "source_id", "destination_id") VALUES (1,1,'Membre','Fourniture de service','<p>Here is the description of this relation</p>','2020-05-20 22:49:47','2021-08-17 08:20:46',NULL,1,6),(2,2,'Membre','Fournisseur de service','<p>Member description</p>','2020-05-20 23:35:11','2021-09-19 11:12:19',NULL,2,6),(3,1,'Fournisseur','Fournisseur de service','<p>description de la relation entre A et le B</p>','2020-05-20 23:39:24','2021-08-17 08:20:59',NULL,7,1),(4,2,'Membre','Fourniture de service','<p>Description du service</p>','2020-05-21 02:23:03','2021-05-23 13:06:05',NULL,2,6),(5,0,'Membre','Fournisseur de service',NULL,'2020-05-21 02:23:35','2021-05-23 13:05:18',NULL,2,6),(6,0,'Fournisseur','fourniture de service',NULL,'2020-05-21 02:24:35','2020-05-21 02:24:35',NULL,7,2),(7,0,'Membre','fourniture de service',NULL,'2020-05-21 02:26:43','2020-05-21 02:26:43',NULL,4,6),(8,3,'Rapporte',NULL,NULL,'2020-05-21 02:32:19','2020-07-05 10:10:01',NULL,1,5),(9,0,'Fournisseur','fourniture de service',NULL,'2020-05-21 02:33:33','2020-05-21 02:33:33',NULL,9,1),(10,2,'Rapporte','Fournisseur de service','<p>Régelement général APD34</p>','2020-05-22 21:21:02','2020-08-24 14:31:29',NULL,1,8),(11,2,'toto',NULL,NULL,'2020-07-05 10:14:15','2020-07-05 10:14:55','2020-07-05 10:14:55',3,2),(12,1,'Fournisseur','Fournisseur de service','<p>Analyse de risques</p>','2020-08-24 14:23:30','2020-08-24 14:23:48',NULL,2,4),(13,1,'Fournisseur','Fourniture de service','<p>Description du service</p>','2020-10-14 17:06:24','2021-05-23 13:06:34',NULL,2,12);
-/*!40000 ALTER TABLE "relations" ENABLE KEYS */;
+LOCK TABLES `phones` WRITE;
+/*!40000 ALTER TABLE `phones` DISABLE KEYS */;
+INSERT INTO `phones` (`id`, `name`, `description`, `type`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `physical_switch_id`) VALUES (1,'Phone 01','<p>Téléphone de test</p>','MOTOROAL 3110','2020-07-21 05:16:46','2020-07-25 07:15:17',NULL,1,1,NULL),(2,'Phone 03','<p>Special AA phone</p>','Top secret red phne','2020-07-21 05:18:01','2020-07-25 07:25:38',NULL,2,4,NULL),(3,'Phone 02','<p>Description phone 02</p>','IPhone 2','2020-07-25 06:52:23','2020-07-25 07:25:19',NULL,2,3,NULL);
+/*!40000 ALTER TABLE `phones` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "routers"
+-- Dumping data for table `physical_router_vlan`
 --
 
-LOCK TABLES "routers" WRITE;
-/*!40000 ALTER TABLE "routers" DISABLE KEYS */;
-INSERT INTO "routers" ("id", "name", "description", "rules", "created_at", "updated_at", "deleted_at", "ip_addresses") VALUES (1,'ROUT_00','<p>Description du routeur 1</p>','<p>liste des règles dans //serveur/liste.txt</p>','2020-07-13 17:32:25','2021-09-21 15:00:36',NULL,'10.50.1.1, 10.60.1.1, 10.70.1.1'),(2,'ROUT_01','<p>Description of router 01</p>','<p>list of rules :&nbsp;</p><ul><li>a</li><li>b</li><li>c</li><li>d</li></ul>','2021-09-21 13:47:47','2021-09-21 14:53:35',NULL,'10.10.0.1, 10.20.0.1, 10.30.0.1'),(3,'ROUT_02','<p>This is the second router</p>',NULL,'2021-09-21 13:52:16','2021-09-21 15:01:18',NULL,'10.30.1.1, 10.40.1.1');
-/*!40000 ALTER TABLE "routers" ENABLE KEYS */;
+LOCK TABLES `physical_router_vlan` WRITE;
+/*!40000 ALTER TABLE `physical_router_vlan` DISABLE KEYS */;
+INSERT INTO `physical_router_vlan` (`physical_router_id`, `vlan_id`) VALUES (1,1),(1,3),(2,3);
+/*!40000 ALTER TABLE `physical_router_vlan` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "security_devices"
+-- Dumping data for table `physical_routers`
 --
 
-LOCK TABLES "security_devices" WRITE;
-/*!40000 ALTER TABLE "security_devices" DISABLE KEYS */;
-INSERT INTO "security_devices" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'FW01','<p>Firewall proncipal</p>','2020-07-14 17:01:21','2020-07-14 17:01:21',NULL),(2,'FW02','<p>Backup Fireall</p>','2020-07-14 17:02:21','2020-07-14 17:02:21',NULL);
-/*!40000 ALTER TABLE "security_devices" ENABLE KEYS */;
+LOCK TABLES `physical_routers` WRITE;
+/*!40000 ALTER TABLE `physical_routers` DISABLE KEYS */;
+INSERT INTO `physical_routers` (`id`, `description`, `type`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`, `name`) VALUES (1,'<p>Routeur prncipal</p>','Fortinet','2020-07-10 06:58:53','2021-10-12 19:08:21',NULL,1,1,1,'R1'),(2,'<p>Routeur secondaire</p>','CISCO','2020-07-10 07:19:11','2020-07-25 08:28:17',NULL,2,3,5,'R2');
+/*!40000 ALTER TABLE `physical_routers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "sites"
+-- Dumping data for table `physical_security_devices`
 --
 
-LOCK TABLES "sites" WRITE;
-/*!40000 ALTER TABLE "sites" DISABLE KEYS */;
-INSERT INTO "sites" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Site A','<p>Description du site A</p>','2020-06-21 04:36:41','2020-06-21 04:36:41',NULL),(2,'Site B','<p>Description du site B</p>','2020-06-21 04:36:53','2020-06-21 04:36:53',NULL),(3,'Site C','<p>Description du Site C</p>','2020-06-21 04:37:05','2020-06-21 04:37:05',NULL),(4,'Test1','<p>site de test</p>','2020-07-24 19:12:29','2020-07-24 19:12:56','2020-07-24 19:12:56'),(5,'testsite','<p>description here</p>','2021-04-12 15:31:40','2021-04-12 15:32:04','2021-04-12 15:32:04'),(6,'Site Z',NULL,'2021-06-18 05:36:03','2021-10-19 16:51:22','2021-10-19 16:51:22'),(7,'Site 0',NULL,'2021-06-18 05:36:12','2021-08-17 17:52:52','2021-08-17 17:52:52');
-/*!40000 ALTER TABLE "sites" ENABLE KEYS */;
+LOCK TABLES `physical_security_devices` WRITE;
+/*!40000 ALTER TABLE `physical_security_devices` DISABLE KEYS */;
+INSERT INTO `physical_security_devices` (`id`, `name`, `type`, `description`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`) VALUES (1,'Magic Gate','Gate','<p>BIG Magic Gate</p>','2021-05-20 14:40:43','2021-11-13 20:29:45',NULL,1,1,1),(2,'Magic Firewall','Firewall','<p>The magic firewall - PT3743</p>','2021-06-07 14:56:26','2021-11-13 20:29:32',NULL,2,3,5),(3,'Sensor-1','Sensor','<p>Temperature sensor</p>','2021-11-13 20:37:14','2021-11-13 20:37:56',NULL,1,3,NULL);
+/*!40000 ALTER TABLE `physical_security_devices` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "storage_devices"
+-- Dumping data for table `physical_servers`
 --
 
-LOCK TABLES "storage_devices" WRITE;
-/*!40000 ALTER TABLE "storage_devices" DISABLE KEYS */;
-INSERT INTO "storage_devices" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "bay_id", "physical_switch_id") VALUES (1,'DiskServer 1','<p>Description du serveur d stockage 1</p>','2020-06-21 15:30:16','2020-06-21 15:30:16',NULL,1,2,3,NULL),(2,'Oracle Server','<p>Main oracle server</p>','2020-06-21 15:33:51','2020-06-21 15:34:38',NULL,1,2,2,NULL);
-/*!40000 ALTER TABLE "storage_devices" ENABLE KEYS */;
+LOCK TABLES `physical_servers` WRITE;
+/*!40000 ALTER TABLE `physical_servers` DISABLE KEYS */;
+INSERT INTO `physical_servers` (`id`, `name`, `description`, `responsible`, `configuration`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`, `physical_switch_id`, `type`) VALUES (1,'Serveur A1','<p>Description du serveur A1</p>','Marc','<p>OS: OS2<br>IP : 127.0.0.1<br>&nbsp;</p>','2020-06-21 05:27:02','2021-11-27 11:12:00',NULL,1,2,4,NULL,'System 840'),(2,'Serveur A2','<p>Description du serveur A2</p>','Marc','<p>Configuration du serveur A<br>OS : Linux 23.4<br>RAM: 32G</p>','2020-06-21 05:27:58','2021-11-27 11:12:12',NULL,3,5,6,NULL,'System 840'),(3,'Serveur A3','<p>Serveur mobile</p>','Marc','<p>None</p>','2020-07-14 15:30:48','2021-11-27 11:12:24',NULL,1,1,3,NULL,'System 840'),(4,'ZZ99','<p>Zoro server</p>',NULL,NULL,'2020-07-14 15:37:50','2020-08-25 14:54:58','2020-08-25 14:54:58',3,5,NULL,NULL,NULL),(5,'K01','<p>Serveur K01</p>',NULL,'<p>TOP CPU<br>TOP RAM</p>','2020-07-15 14:37:04','2020-08-29 12:08:09','2020-08-29 12:08:09',1,1,3,NULL,NULL),(6,'Mainframe 01','<p>Central accounting system</p>','Marc','<p>40G RAM<br>360P Disk<br>CICS / Cobol</p>','2020-09-05 08:02:49','2021-11-27 11:11:43',NULL,1,1,1,2,'Type 404'),(7,'Mainframe T1','<p>Mainframe de test</p>','Marc','<p>IDEM prod</p>','2020-09-05 08:22:18','2021-11-27 11:11:01',NULL,2,3,4,2,'HAL 340'),(8,'Serveur A4','<p>Departmental server</p>','Marc','<p>Standard configuration</p>','2021-06-22 15:34:33','2021-11-27 11:12:50',NULL,2,3,5,NULL,'Mini 900/2');
+/*!40000 ALTER TABLE `physical_servers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "subnetworks"
+-- Dumping data for table `physical_switches`
 --
 
-LOCK TABLES "subnetworks" WRITE;
-/*!40000 ALTER TABLE "subnetworks" DISABLE KEYS */;
-INSERT INTO "subnetworks" ("id", "description", "address", "ip_allocation_type", "responsible_exp", "dmz", "wifi", "name", "created_at", "updated_at", "deleted_at", "connected_subnets_id", "gateway_id", "zone", "vlan_id", "network_id", "default_gateway") VALUES (1,'<p>Description du sous-réseau 1</p>','10.10.0.0 /16','Static','Marc','non','non','Subnet1','2020-06-23 12:35:41','2021-11-16 20:24:29',NULL,NULL,1,'ZONE_ACCUEIL',2,1,'10.10.0.1'),(2,'<p>Description du subnet 2</p>','10.20.0.0/16','Static','Henri','Oui','Oui','Subnet2','2020-07-04 07:35:10','2021-09-21 14:52:35',NULL,NULL,5,'ZONE_WORK',1,1,'10.20.0.1'),(3,'<p>Description du quatrième subnet</p>','10.40.0.0/16','Static','Jean','non','non','Subnet4','2020-11-06 12:56:33','2021-08-20 07:56:50',NULL,2,5,'ZONE_WORK',4,1,'10.40.0.1'),(4,'<p>descrption subnet 3</p>','8.8.8.8 /  255.255.255.0',NULL,NULL,NULL,NULL,'test subnet 3','2021-02-24 11:49:16','2021-02-24 11:49:33','2021-02-24 11:49:33',NULL,NULL,NULL,NULL,NULL,NULL),(5,'<p>Troisième sous-réseau</p>','10.30.0.0/16','Static','Jean','non','non','Subnet3','2021-05-19 14:48:39','2021-08-20 07:57:01',NULL,NULL,1,'ZONE_WORK',3,1,'10.30.0.1'),(6,'<p>Description du cinquième réseau</p>','10.50.0.0/16','Fixed','Jean','Oui','non','Subnet5','2021-08-17 11:35:28','2021-08-26 15:27:41',NULL,NULL,1,'ZONE_BACKUP',5,1,'10.50.0.1'),(7,'<p>Description du sixième sous-réseau</p>','10.60.0.0/16','Fixed','Jean','non','non','Subnet6','2021-08-17 16:32:47','2021-08-26 15:27:57',NULL,2,4,'ZONE_APP',6,2,'10.60.1.1'),(8,'<p>Test</p>',NULL,NULL,NULL,NULL,NULL,'Subnet7','2021-08-18 16:05:50','2021-08-18 16:10:19','2021-08-18 16:10:19',NULL,NULL,NULL,NULL,NULL,NULL),(9,'<p>Sous-réseau numéro sept</p>','10.70.0.0/16','Static','Jean','Oui','Oui','Subnet7','2021-08-18 16:11:10','2021-08-26 15:27:30',NULL,NULL,NULL,'ZONE_BACKUP',5,2,'10.70.0.1'),(10,'<p>Sous réseau démilitarisé</p>','10.70.0.0/32','Fixed','Jean','Oui','non','Subnet8','2021-08-18 16:33:48','2021-08-26 15:28:10',NULL,NULL,1,'ZONE_DMZ',7,1,'10.70.0.1'),(11,'<p>Description subnet 9</p>','10.90.0.0/32',NULL,'Jean','non','non','Subnet9','2021-09-07 16:41:02','2021-09-07 16:41:02',NULL,NULL,NULL,'ZONE_DATA',8,1,'10.90.1.1');
-/*!40000 ALTER TABLE "subnetworks" ENABLE KEYS */;
+LOCK TABLES `physical_switches` WRITE;
+/*!40000 ALTER TABLE `physical_switches` DISABLE KEYS */;
+INSERT INTO `physical_switches` (`id`, `name`, `description`, `type`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`) VALUES (1,'Switch de test','<p>Master test switch.</p>','Nortel A39','2020-07-17 13:29:09','2022-04-25 16:22:02',NULL,1,2,4),(2,'Switch 2','<p>Description switch 2</p>','Alcatel 430','2020-07-17 13:31:41','2020-07-17 13:31:41',NULL,1,1,1),(3,'Switch 1','<p>Desription du premier switch.</p>','Nortel 2300','2020-07-25 05:27:27','2022-04-25 12:55:06',NULL,2,3,5),(4,'Switch 3','<p>Desciption du switch 3</p>','Alcatel 3500','2020-07-25 07:42:51','2020-07-25 07:43:21',NULL,3,5,6),(5,'AB','<p>Test 2 chars switch</p>',NULL,'2020-08-22 04:19:45','2020-08-27 16:04:20','2020-08-27 16:04:20',NULL,NULL,NULL);
+/*!40000 ALTER TABLE `physical_switches` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "tasks"
+-- Dumping data for table `processes`
 --
 
-LOCK TABLES "tasks" WRITE;
-/*!40000 ALTER TABLE "tasks" DISABLE KEYS */;
-INSERT INTO "tasks" ("id", "nom", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Tâche 2','Descriptionde la tâche 2','2020-06-13 00:04:07','2020-06-13 00:04:07',NULL),(2,'Tache 1','Description de la tâche 1','2020-06-13 00:04:21','2020-06-13 00:04:21',NULL),(3,'Tâche 3','Description de la tâche 3','2020-06-13 00:04:41','2020-06-13 00:04:41',NULL);
-/*!40000 ALTER TABLE "tasks" ENABLE KEYS */;
+LOCK TABLES `processes` WRITE;
+/*!40000 ALTER TABLE `processes` DISABLE KEYS */;
+INSERT INTO `processes` (`id`, `identifiant`, `description`, `owner`, `security_need_c`, `in_out`, `dummy`, `created_at`, `updated_at`, `deleted_at`, `macroprocess_id`, `security_need_i`, `security_need_a`, `security_need_t`) VALUES (1,'Processus 1','<p>Description du processus 1</p>','Ched',3,'<ul><li>pommes</li><li>poires</li><li>cerise</li></ul><p>&lt;test</p>',NULL,'2020-06-17 14:36:24','2021-09-22 11:38:57',NULL,1,2,3,1),(2,'Processus 2','<p>Description du processus 2</p>','Ched',3,'<p>1 2 3 4 5 6</p>',NULL,'2020-06-17 14:36:58','2021-09-22 10:59:14',NULL,10,4,2,4),(3,'Processus 3','<p>Description du processus 3</p>','Johan',3,'<p>a,b,c</p><p>d,e,f</p>',NULL,'2020-07-01 15:50:27','2021-08-17 08:22:13',NULL,2,2,3,1),(4,'Processus 4','<p>Description du processus 4</p>','Paul',4,'<ul><li>chaussettes</li><li>pantalon</li><li>chaussures</li></ul>',NULL,'2020-08-18 15:00:36','2021-08-17 08:22:29',NULL,2,2,2,2),(5,'totoat','<p>tto</p>',NULL,1,'<p>sgksdùmfk</p>',NULL,'2020-08-27 13:16:56','2020-08-27 13:17:01','2020-08-27 13:17:01',1,NULL,NULL,NULL),(6,'ptest','<p>description de ptest</p>',NULL,0,'<p>toto titi tutu</p>',NULL,'2020-08-29 11:10:23','2020-08-29 11:10:28','2020-08-29 11:10:28',NULL,NULL,NULL,NULL),(7,'ptest2','<p>fdfsdfsdf</p>',NULL,1,'<p>fdfsdfsd</p>',NULL,'2020-08-29 11:16:42','2020-08-29 11:17:09','2020-08-29 11:17:09',1,NULL,NULL,NULL),(8,'ptest3','<p>processus de test 3</p>','CHEM - Facturation',3,'<p>dsfsdf sdf sdf sd fsd fsd f s</p>',NULL,'2020-08-29 11:19:13','2020-08-29 11:20:59','2020-08-29 11:20:59',1,NULL,NULL,NULL),(9,'Processus 5','<p>Description du cinquième processus</p>','Paul',4,'<ul><li>chat</li><li>chien</li><li>poisson</li></ul>',NULL,'2021-05-14 07:10:02','2021-09-22 10:59:14',NULL,10,3,2,3),(10,'Proc 6',NULL,NULL,0,NULL,NULL,'2021-10-08 19:18:28','2021-10-08 19:28:38','2021-10-08 19:28:38',NULL,0,0,0);
+/*!40000 ALTER TABLE `processes` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "vlans"
+-- Dumping data for table `relations`
 --
 
-LOCK TABLES "vlans" WRITE;
-/*!40000 ALTER TABLE "vlans" DISABLE KEYS */;
-INSERT INTO "vlans" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'VLAN_2','VLAN Wifi','2020-07-07 14:31:53','2020-07-07 14:39:10',NULL),(2,'VLAN_1','VLAN publc','2020-07-07 14:34:30','2020-07-07 14:38:53',NULL),(3,'VLAN_3','VLAN application','2020-07-07 14:38:41','2020-07-08 19:35:53',NULL),(4,'VLAN_4','Vlan Client','2020-07-08 19:34:11','2020-07-08 19:36:06',NULL),(5,'VLAN_5','Test Production','2020-07-11 17:12:03','2021-08-18 17:35:54',NULL),(6,'VLAN_6','VLAN démilitarisé','2020-07-11 17:14:55','2021-08-18 17:36:12',NULL),(7,'VLAN_7','Description du VLAN 7','2021-09-07 16:35:28','2021-09-07 16:35:28',NULL),(8,'VLAN_8','Description du VLAN 8','2021-09-07 16:36:20','2021-09-07 16:36:20',NULL);
-/*!40000 ALTER TABLE "vlans" ENABLE KEYS */;
+LOCK TABLES `relations` WRITE;
+/*!40000 ALTER TABLE `relations` DISABLE KEYS */;
+INSERT INTO `relations` (`id`, `importance`, `name`, `type`, `description`, `created_at`, `updated_at`, `deleted_at`, `source_id`, `destination_id`) VALUES (1,1,'Membre','Fourniture de service','<p>Here is the description of this relation</p>','2020-05-20 22:49:47','2021-08-17 08:20:46',NULL,1,6),(2,2,'Membre','Fournisseur de service','<p>Member description</p>','2020-05-20 23:35:11','2021-09-19 11:12:19',NULL,2,6),(3,1,'Fournisseur','Fournisseur de service','<p>description de la relation entre A et le B</p>','2020-05-20 23:39:24','2021-08-17 08:20:59',NULL,7,1),(4,2,'Membre','Fourniture de service','<p>Description du service</p>','2020-05-21 02:23:03','2021-05-23 13:06:05',NULL,2,6),(5,0,'Membre','Fournisseur de service',NULL,'2020-05-21 02:23:35','2021-05-23 13:05:18',NULL,2,6),(6,0,'Fournisseur','fourniture de service',NULL,'2020-05-21 02:24:35','2020-05-21 02:24:35',NULL,7,2),(7,0,'Membre','fourniture de service',NULL,'2020-05-21 02:26:43','2020-05-21 02:26:43',NULL,4,6),(8,3,'Rapporte',NULL,NULL,'2020-05-21 02:32:19','2020-07-05 10:10:01',NULL,1,5),(9,0,'Fournisseur','fourniture de service',NULL,'2020-05-21 02:33:33','2020-05-21 02:33:33',NULL,9,1),(10,2,'Rapporte','Fournisseur de service','<p>Régelement général APD34</p>','2020-05-22 21:21:02','2020-08-24 14:31:29',NULL,1,8),(11,2,'toto',NULL,NULL,'2020-07-05 10:14:15','2020-07-05 10:14:55','2020-07-05 10:14:55',3,2),(12,1,'Fournisseur','Fournisseur de service','<p>Analyse de risques</p>','2020-08-24 14:23:30','2020-08-24 14:23:48',NULL,2,4),(13,1,'Fournisseur','Fourniture de service','<p>Description du service</p>','2020-10-14 17:06:24','2021-05-23 13:06:34',NULL,2,12);
+/*!40000 ALTER TABLE `relations` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "wans"
+-- Dumping data for table `routers`
 --
 
-LOCK TABLES "wans" WRITE;
-/*!40000 ALTER TABLE "wans" DISABLE KEYS */;
-INSERT INTO "wans" ("id", "name", "created_at", "updated_at", "deleted_at") VALUES (1,'WAN01','2021-05-21 10:58:42','2021-05-21 10:58:42',NULL);
-/*!40000 ALTER TABLE "wans" ENABLE KEYS */;
+LOCK TABLES `routers` WRITE;
+/*!40000 ALTER TABLE `routers` DISABLE KEYS */;
+INSERT INTO `routers` (`id`, `name`, `description`, `rules`, `created_at`, `updated_at`, `deleted_at`, `ip_addresses`) VALUES (1,'ROUT_00','<p>Description du routeur 1</p>','<p>liste des règles dans //serveur/liste.txt</p>','2020-07-13 17:32:25','2021-09-21 15:00:36',NULL,'10.50.1.1, 10.60.1.1, 10.70.1.1'),(2,'ROUT_01','<p>Description of router 01</p>','<p>list of rules :&nbsp;</p><ul><li>a</li><li>b</li><li>c</li><li>d</li></ul>','2021-09-21 13:47:47','2021-09-21 14:53:35',NULL,'10.10.0.1, 10.20.0.1, 10.30.0.1'),(3,'ROUT_02','<p>This is the second router</p>',NULL,'2021-09-21 13:52:16','2021-09-21 15:01:18',NULL,'10.30.1.1, 10.40.1.1');
+/*!40000 ALTER TABLE `routers` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "wifi_terminals"
+-- Dumping data for table `security_devices`
 --
 
-LOCK TABLES "wifi_terminals" WRITE;
-/*!40000 ALTER TABLE "wifi_terminals" DISABLE KEYS */;
-INSERT INTO "wifi_terminals" ("id", "name", "description", "type", "created_at", "updated_at", "deleted_at", "site_id", "building_id") VALUES (1,'WIFI_01','<p>Borne wifi 01</p>','Alcatel 3500','2020-07-22 14:44:37','2020-07-22 14:44:37',NULL,1,2),(2,'WIFI_02','<p>Borne Wifi 2</p>','ALCALSYS 3001','2021-06-07 14:37:47','2021-06-07 14:37:47',NULL,2,1),(3,'WIFI_03','<p>Borne Wifi 3</p>','SYSTEL 3310','2021-06-07 14:42:29','2021-06-07 14:43:18',NULL,3,4);
-/*!40000 ALTER TABLE "wifi_terminals" ENABLE KEYS */;
+LOCK TABLES `security_devices` WRITE;
+/*!40000 ALTER TABLE `security_devices` DISABLE KEYS */;
+INSERT INTO `security_devices` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'FW01','<p>Firewall proncipal</p>','2020-07-14 17:01:21','2020-07-14 17:01:21',NULL),(2,'FW02','<p>Backup Fireall</p>','2020-07-14 17:02:21','2020-07-14 17:02:21',NULL);
+/*!40000 ALTER TABLE `security_devices` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "workstations"
+-- Dumping data for table `sites`
 --
 
-LOCK TABLES "workstations" WRITE;
-/*!40000 ALTER TABLE "workstations" DISABLE KEYS */;
-INSERT INTO "workstations" ("id", "name", "description", "created_at", "updated_at", "deleted_at", "site_id", "building_id", "physical_switch_id", "type") VALUES (1,'Workstation 1','<p>Station de travail compta</p>','2020-06-21 15:09:04','2022-03-20 11:37:13',NULL,1,7,NULL,'ThinThink 460'),(2,'Workstation 2','<p>Station de travail accueil</p>','2020-06-21 15:09:54','2021-10-20 07:14:59',NULL,2,3,NULL,'ThinThink 410'),(3,'Workstation 3','<p>Station de travail back-office</p>','2020-06-21 15:17:57','2021-10-20 07:15:25',NULL,2,4,NULL,'ThinThink 420');
-/*!40000 ALTER TABLE "workstations" ENABLE KEYS */;
+LOCK TABLES `sites` WRITE;
+/*!40000 ALTER TABLE `sites` DISABLE KEYS */;
+INSERT INTO `sites` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Site A','<p>Description du site A</p>','2020-06-21 04:36:41','2020-06-21 04:36:41',NULL),(2,'Site B','<p>Description du site B</p>','2020-06-21 04:36:53','2020-06-21 04:36:53',NULL),(3,'Site C','<p>Description du Site C</p>','2020-06-21 04:37:05','2020-06-21 04:37:05',NULL),(4,'Test1','<p>site de test</p>','2020-07-24 19:12:29','2020-07-24 19:12:56','2020-07-24 19:12:56'),(5,'testsite','<p>description here</p>','2021-04-12 15:31:40','2021-04-12 15:32:04','2021-04-12 15:32:04'),(6,'Site Z',NULL,'2021-06-18 05:36:03','2021-10-19 16:51:22','2021-10-19 16:51:22'),(7,'Site 0',NULL,'2021-06-18 05:36:12','2021-08-17 17:52:52','2021-08-17 17:52:52');
+/*!40000 ALTER TABLE `sites` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Dumping data for table "zone_admins"
+-- Dumping data for table `storage_devices`
 --
 
-LOCK TABLES "zone_admins" WRITE;
-/*!40000 ALTER TABLE "zone_admins" DISABLE KEYS */;
-INSERT INTO "zone_admins" ("id", "name", "description", "created_at", "updated_at", "deleted_at") VALUES (1,'Enreprise','<p>Zone d\'administration de l\'entreprise</p>','2020-07-03 07:49:03','2021-05-23 13:07:18',NULL);
-/*!40000 ALTER TABLE "zone_admins" ENABLE KEYS */;
+LOCK TABLES `storage_devices` WRITE;
+/*!40000 ALTER TABLE `storage_devices` DISABLE KEYS */;
+INSERT INTO `storage_devices` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `bay_id`, `physical_switch_id`) VALUES (1,'DiskServer 1','<p>Description du serveur d stockage 1</p>','2020-06-21 15:30:16','2020-06-21 15:30:16',NULL,1,2,3,NULL),(2,'Oracle Server','<p>Main oracle server</p>','2020-06-21 15:33:51','2020-06-21 15:34:38',NULL,1,2,2,NULL);
+/*!40000 ALTER TABLE `storage_devices` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `subnetworks`
+--
+
+LOCK TABLES `subnetworks` WRITE;
+/*!40000 ALTER TABLE `subnetworks` DISABLE KEYS */;
+INSERT INTO `subnetworks` (`id`, `description`, `address`, `ip_allocation_type`, `responsible_exp`, `dmz`, `wifi`, `name`, `created_at`, `updated_at`, `deleted_at`, `connected_subnets_id`, `gateway_id`, `zone`, `vlan_id`, `network_id`, `default_gateway`) VALUES (1,'<p>Description du sous-réseau 1</p>','10.10.0.0 /16','Static','Marc','non','non','Subnet1','2020-06-23 12:35:41','2021-11-16 20:24:29',NULL,NULL,1,'ZONE_ACCUEIL',2,1,'10.10.0.1'),(2,'<p>Description du subnet 2</p>','10.20.0.0/16','Static','Henri','Oui','Oui','Subnet2','2020-07-04 07:35:10','2021-09-21 14:52:35',NULL,NULL,5,'ZONE_WORK',1,1,'10.20.0.1'),(3,'<p>Description du quatrième subnet</p>','10.40.0.0/16','Static','Jean','non','non','Subnet4','2020-11-06 12:56:33','2021-08-20 07:56:50',NULL,2,5,'ZONE_WORK',4,1,'10.40.0.1'),(4,'<p>descrption subnet 3</p>','8.8.8.8 /  255.255.255.0',NULL,NULL,NULL,NULL,'test subnet 3','2021-02-24 11:49:16','2021-02-24 11:49:33','2021-02-24 11:49:33',NULL,NULL,NULL,NULL,NULL,NULL),(5,'<p>Troisième sous-réseau</p>','10.30.0.0/16','Static','Jean','non','non','Subnet3','2021-05-19 14:48:39','2021-08-20 07:57:01',NULL,NULL,1,'ZONE_WORK',3,1,'10.30.0.1'),(6,'<p>Description du cinquième réseau</p>','10.50.0.0/16','Fixed','Jean','Oui','non','Subnet5','2021-08-17 11:35:28','2021-08-26 15:27:41',NULL,NULL,1,'ZONE_BACKUP',5,1,'10.50.0.1'),(7,'<p>Description du sixième sous-réseau</p>','10.60.0.0/16','Fixed','Jean','non','non','Subnet6','2021-08-17 16:32:47','2021-08-26 15:27:57',NULL,2,4,'ZONE_APP',6,2,'10.60.1.1'),(8,'<p>Test</p>',NULL,NULL,NULL,NULL,NULL,'Subnet7','2021-08-18 16:05:50','2021-08-18 16:10:19','2021-08-18 16:10:19',NULL,NULL,NULL,NULL,NULL,NULL),(9,'<p>Sous-réseau numéro sept</p>','10.70.0.0/16','Static','Jean','Oui','Oui','Subnet7','2021-08-18 16:11:10','2021-08-26 15:27:30',NULL,NULL,NULL,'ZONE_BACKUP',5,2,'10.70.0.1'),(10,'<p>Sous réseau démilitarisé</p>','10.70.0.0/32','Fixed','Jean','Oui','non','Subnet8','2021-08-18 16:33:48','2021-08-26 15:28:10',NULL,NULL,1,'ZONE_DMZ',7,1,'10.70.0.1'),(11,'<p>Description subnet 9</p>','10.90.0.0/32',NULL,'Jean','non','non','Subnet9','2021-09-07 16:41:02','2021-09-07 16:41:02',NULL,NULL,NULL,'ZONE_DATA',8,1,'10.90.1.1');
+/*!40000 ALTER TABLE `subnetworks` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `tasks`
+--
+
+LOCK TABLES `tasks` WRITE;
+/*!40000 ALTER TABLE `tasks` DISABLE KEYS */;
+INSERT INTO `tasks` (`id`, `nom`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Tâche 2','Descriptionde la tâche 2','2020-06-13 00:04:07','2020-06-13 00:04:07',NULL),(2,'Tache 1','Description de la tâche 1','2020-06-13 00:04:21','2020-06-13 00:04:21',NULL),(3,'Tâche 3','Description de la tâche 3','2020-06-13 00:04:41','2020-06-13 00:04:41',NULL);
+/*!40000 ALTER TABLE `tasks` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `vlans`
+--
+
+LOCK TABLES `vlans` WRITE;
+/*!40000 ALTER TABLE `vlans` DISABLE KEYS */;
+INSERT INTO `vlans` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'VLAN_2','VLAN Wifi','2020-07-07 14:31:53','2020-07-07 14:39:10',NULL),(2,'VLAN_1','VLAN publc','2020-07-07 14:34:30','2020-07-07 14:38:53',NULL),(3,'VLAN_3','VLAN application','2020-07-07 14:38:41','2020-07-08 19:35:53',NULL),(4,'VLAN_4','Vlan Client','2020-07-08 19:34:11','2020-07-08 19:36:06',NULL),(5,'VLAN_5','Test Production','2020-07-11 17:12:03','2021-08-18 17:35:54',NULL),(6,'VLAN_6','VLAN démilitarisé','2020-07-11 17:14:55','2021-08-18 17:36:12',NULL),(7,'VLAN_7','Description du VLAN 7','2021-09-07 16:35:28','2021-09-07 16:35:28',NULL),(8,'VLAN_8','Description du VLAN 8','2021-09-07 16:36:20','2021-09-07 16:36:20',NULL);
+/*!40000 ALTER TABLE `vlans` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `wans`
+--
+
+LOCK TABLES `wans` WRITE;
+/*!40000 ALTER TABLE `wans` DISABLE KEYS */;
+INSERT INTO `wans` (`id`, `name`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'WAN01','2021-05-21 10:58:42','2021-05-21 10:58:42',NULL);
+/*!40000 ALTER TABLE `wans` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `wifi_terminals`
+--
+
+LOCK TABLES `wifi_terminals` WRITE;
+/*!40000 ALTER TABLE `wifi_terminals` DISABLE KEYS */;
+INSERT INTO `wifi_terminals` (`id`, `name`, `description`, `type`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`) VALUES (1,'WIFI_01','<p>Borne wifi 01</p>','Alcatel 3500','2020-07-22 14:44:37','2020-07-22 14:44:37',NULL,1,2),(2,'WIFI_02','<p>Borne Wifi 2</p>','ALCALSYS 3001','2021-06-07 14:37:47','2021-06-07 14:37:47',NULL,2,1),(3,'WIFI_03','<p>Borne Wifi 3</p>','SYSTEL 3310','2021-06-07 14:42:29','2021-06-07 14:43:18',NULL,3,4);
+/*!40000 ALTER TABLE `wifi_terminals` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `workstations`
+--
+
+LOCK TABLES `workstations` WRITE;
+/*!40000 ALTER TABLE `workstations` DISABLE KEYS */;
+INSERT INTO `workstations` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`, `site_id`, `building_id`, `physical_switch_id`, `type`) VALUES (1,'Workstation 1','<p>Station de travail compta</p>','2020-06-21 15:09:04','2022-03-20 11:37:13',NULL,1,7,NULL,'ThinThink 460'),(2,'Workstation 2','<p>Station de travail accueil</p>','2020-06-21 15:09:54','2021-10-20 07:14:59',NULL,2,3,NULL,'ThinThink 410'),(3,'Workstation 3','<p>Station de travail back-office</p>','2020-06-21 15:17:57','2021-10-20 07:15:25',NULL,2,4,NULL,'ThinThink 420');
+/*!40000 ALTER TABLE `workstations` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `zone_admins`
+--
+
+LOCK TABLES `zone_admins` WRITE;
+/*!40000 ALTER TABLE `zone_admins` DISABLE KEYS */;
+INSERT INTO `zone_admins` (`id`, `name`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES (1,'Enreprise','<p>Zone d\'administration de l\'entreprise</p>','2020-07-03 07:49:03','2021-05-23 13:07:18',NULL);
+/*!40000 ALTER TABLE `zone_admins` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-05-17  5:00:41
+-- Dump completed on 2022-05-20  18:03:47

--- a/pg_mercator_data.sql
+++ b/pg_mercator_data.sql
@@ -1,0 +1,1507 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.10 (Ubuntu 12.10-0ubuntu0.20.04.1)
+-- Dumped by pg_dump version 12.10 (Ubuntu 12.10-0ubuntu0.20.04.1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Data for Name: activities; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.activities (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Activité 1	<p>Description de l'activité 1</p>	2020-06-10 15:20:42	2020-06-10 15:20:42	\N
+2	Activité 2	<p>Description de l'activité de test</p>	2020-06-10 17:44:26	2020-06-13 06:03:26	\N
+3	Activité 3	<p>Description de l'activité 3</p>	2020-06-13 06:57:08	2020-06-13 06:57:08	\N
+4	Activité 4	<p>Description de l'acivité 4</p>	2020-06-13 06:57:24	2020-06-13 06:57:24	\N
+5	Activité principale	<p>Description de l'activité principale</p>	2020-08-15 06:19:53	2020-08-15 06:19:53	\N
+6	AAA	test a1	2021-03-22 20:06:55	2021-03-22 20:07:00	2021-03-22 20:07:00
+7	AAA	test AAA	2021-03-22 20:13:43	2021-03-22 20:14:05	2021-03-22 20:14:05
+8	AAA	test 2 aaa	2021-03-22 20:14:16	2021-03-22 20:14:45	2021-03-22 20:14:45
+9	AAA1	test 3 AAA	2021-03-22 20:14:40	2021-03-22 20:19:09	2021-03-22 20:19:09
+10	Activité 0	<p>Description de l'activité zéro</p>	\N	2021-05-15 09:40:16	\N
+11	test	dqqsd	2021-08-02 22:03:46	2021-09-22 12:59:48	2021-09-22 12:59:48
+\.
+
+
+--
+-- Data for Name: operations; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.operations (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Operation 1	<p>Description de l'opération</p>	2020-06-13 02:02:42	2020-06-13 02:02:42	\N
+2	Operation 2	<p>Description de l'opération</p>	2020-06-13 02:02:58	2020-06-13 02:02:58	\N
+3	Operation 3	<p>Desciption de l'opération</p>	2020-06-13 02:03:11	2020-07-15 16:34:52	\N
+4	Operation 4	\N	2020-07-15 16:34:02	2020-07-15 16:34:02	\N
+5	Master operation	<p>Opération maitre</p>	2020-08-15 06:01:40	2020-08-15 06:01:40	\N
+\.
+
+
+--
+-- Data for Name: activity_operation; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.activity_operation (activity_id, operation_id) FROM stdin;
+2	3
+1	1
+1	2
+4	3
+3	1
+1	5
+5	1
+6	1
+10	1
+\.
+
+
+--
+-- Data for Name: macro_processuses; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.macro_processuses (id, name, description, io_elements, security_need_c, owner, created_at, updated_at, deleted_at, security_need_i, security_need_a, security_need_t) FROM stdin;
+1	Macro-Processus 1	<p>Description du macro-processus de test.</p>	<p>Entrant :</p><ul><li>donnée 1</li><li>donnée 2</li><li>donnée 3</li></ul><p>Sortant :</p><ul><li>donnée 4</li><li>donnée 5</li></ul>	4	Nestor	2020-06-10 09:02:16	2021-05-14 15:29:36	\N	3	2	1
+2	Macro-Processus 2	<p>Description du macro-processus</p>	<p>Valeur de test</p>	1	Simon	2020-06-13 03:03:42	2021-05-14 09:21:10	\N	2	3	4
+3	Valeur de test	<p>Valeur de test</p>	<p>Valeur de test</p>	3	All	2020-08-09 07:32:37	2020-08-24 16:45:57	2020-08-24 16:45:57	\N	\N	\N
+4	Proc3	<p>dfsdf</p>	<p>dsfsdf</p>	0	\N	2020-08-31 16:13:55	2020-08-31 16:31:29	2020-08-31 16:31:29	\N	\N	\N
+5	Proc4	<p>dfsdf</p>	<p>dsfsdf</p>	0	\N	2020-08-31 16:19:32	2020-08-31 16:31:29	2020-08-31 16:31:29	\N	\N	\N
+6	Proc5	<p>dfsdf</p>	<p>dsfsdf</p>	0	\N	2020-08-31 16:29:20	2020-08-31 16:31:29	2020-08-31 16:31:29	\N	\N	\N
+7	MP1	<p>sdfsdfs</p>	\N	0	\N	2020-08-31 16:31:40	2020-08-31 16:38:31	2020-08-31 16:38:31	\N	\N	\N
+8	MP2	<p>sdfsdfs</p>	\N	0	\N	2020-08-31 16:37:39	2020-08-31 16:38:31	2020-08-31 16:38:31	\N	\N	\N
+9	MP3	<p>sdfsdfs</p>	\N	0	\N	2020-08-31 16:38:06	2020-08-31 16:38:31	2020-08-31 16:38:31	\N	\N	\N
+10	Macro-Processus 3	<p>Description du troisième macro-processus</p>	<ul><li>un</li><li>deux</li><li>trois</li><li>quatre</li></ul>	2	Nestor	2020-11-24 09:21:38	2021-05-14 09:20:55	\N	2	2	2
+11	Macro-Processus 4	<p>Description du macro processus quatre</p>	<ul><li>crayon</li><li>stylos</li><li>gommes</li></ul>	1	Pirre	2021-05-14 09:19:51	2021-09-22 13:00:08	2021-09-22 13:00:08	1	1	1
+\.
+
+
+--
+-- Data for Name: processes; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.processes (id, identifiant, description, owner, security_need_c, in_out, dummy, created_at, updated_at, deleted_at, macroprocess_id, security_need_i, security_need_a, security_need_t) FROM stdin;
+1	Processus 1	<p>Description du processus 1</p>	Ched	3	<ul><li>pommes</li><li>poires</li><li>cerise</li></ul><p>&lt;test</p>	\N	2020-06-17 16:36:24	2021-09-22 13:38:57	\N	1	2	3	1
+2	Processus 2	<p>Description du processus 2</p>	Ched	3	<p>1 2 3 4 5 6</p>	\N	2020-06-17 16:36:58	2021-09-22 12:59:14	\N	10	4	2	4
+3	Processus 3	<p>Description du processus 3</p>	Johan	3	<p>a,b,c</p><p>d,e,f</p>	\N	2020-07-01 17:50:27	2021-08-17 10:22:13	\N	2	2	3	1
+4	Processus 4	<p>Description du processus 4</p>	Paul	4	<ul><li>chaussettes</li><li>pantalon</li><li>chaussures</li></ul>	\N	2020-08-18 17:00:36	2021-08-17 10:22:29	\N	2	2	2	2
+5	totoat	<p>tto</p>	\N	1	<p>sgksdùmfk</p>	\N	2020-08-27 15:16:56	2020-08-27 15:17:01	2020-08-27 15:17:01	1	\N	\N	\N
+6	ptest	<p>description de ptest</p>	\N	0	<p>toto titi tutu</p>	\N	2020-08-29 13:10:23	2020-08-29 13:10:28	2020-08-29 13:10:28	\N	\N	\N	\N
+7	ptest2	<p>fdfsdfsdf</p>	\N	1	<p>fdfsdfsd</p>	\N	2020-08-29 13:16:42	2020-08-29 13:17:09	2020-08-29 13:17:09	1	\N	\N	\N
+8	ptest3	<p>processus de test 3</p>	CHEM - Facturation	3	<p>dsfsdf sdf sdf sd fsd fsd f s</p>	\N	2020-08-29 13:19:13	2020-08-29 13:20:59	2020-08-29 13:20:59	1	\N	\N	\N
+9	Processus 5	<p>Description du cinquième processus</p>	Paul	4	<ul><li>chat</li><li>chien</li><li>poisson</li></ul>	\N	2021-05-14 09:10:02	2021-09-22 12:59:14	\N	10	3	2	3
+10	Proc 6	\N	\N	0	\N	\N	2021-10-08 21:18:28	2021-10-08 21:28:38	2021-10-08 21:28:38	\N	0	0	0
+\.
+
+
+--
+-- Data for Name: activity_process; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.activity_process (process_id, activity_id) FROM stdin;
+1	1
+1	2
+2	3
+2	4
+3	2
+3	5
+4	5
+5	4
+6	4
+7	3
+8	4
+9	3
+1	10
+\.
+
+
+--
+-- Data for Name: actors; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.actors (id, name, nature, type, contact, created_at, updated_at, deleted_at) FROM stdin;
+1	Jean	Personne	interne	jean@testdomain.org	2020-06-14 13:02:22	2021-05-16 19:37:49	\N
+2	Service 1	Groupe	interne	\N	2020-06-14 13:02:39	2020-06-17 16:43:42	2020-06-17 16:43:42
+3	Service 2	Groupe	Interne	\N	2020-06-14 13:02:54	2020-06-17 16:43:46	2020-06-17 16:43:46
+4	Pierre	Personne	interne	email : pierre@testdomain.com	2020-06-17 16:44:01	2021-05-16 19:38:19	\N
+5	Jacques	personne	interne	Téléphone 1234543423	2020-06-17 16:44:23	2020-06-17 16:44:23	\N
+6	Fournisseur 1	entité	externe	Tel : 1232 32312	2020-06-17 16:44:50	2020-06-17 16:44:50	\N
+\.
+
+
+--
+-- Data for Name: actor_operation; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.actor_operation (operation_id, actor_id) FROM stdin;
+2	1
+1	1
+1	4
+2	5
+3	6
+5	4
+\.
+
+
+--
+-- Data for Name: zone_admins; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.zone_admins (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Enreprise	<p>Zone d'administration de l'entreprise</p>	2020-07-03 09:49:03	2021-05-23 15:07:18	\N
+\.
+
+
+--
+-- Data for Name: annuaires; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.annuaires (id, name, description, solution, created_at, updated_at, deleted_at, zone_admin_id) FROM stdin;
+1	AD01	<p>Annuaire principal&nbsp;</p>	Acive Directory	2020-07-03 09:49:37	2022-03-22 20:33:39	\N	1
+2	Mercator	<p>Cartographie du système d'information</p>	Logiciel développé maison	2020-07-03 12:24:48	2020-07-13 17:12:59	\N	1
+\.
+
+
+--
+-- Data for Name: application_blocks; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.application_blocks (id, name, description, responsible, created_at, updated_at, deleted_at) FROM stdin;
+1	Bloc applicatif 1	<p>Description du bloc applicatif</p>	Jean Pierre	2020-06-13 06:09:01	2020-06-13 06:09:01	\N
+2	Bloc applicatif 2	<p>Second bloc applicatif.</p>	Marcel pierre	2020-06-13 06:10:52	2020-06-17 18:13:33	\N
+3	Bloc applicatif 3	<p>Description du block applicatif 3</p>	Nestor	2020-08-29 14:00:10	2022-03-20 18:53:29	\N
+\.
+
+
+--
+-- Data for Name: application_modules; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.application_modules (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Module 1	<p>Description du module 1</p>	2020-06-13 11:55:34	2020-06-13 11:55:34	\N
+2	Module 2	<p>Description du module 2</p>	2020-06-13 11:55:45	2020-06-13 11:55:45	\N
+3	Module 3	<p>Description du module 3</p>	2020-06-13 11:56:00	2020-06-13 11:56:00	\N
+4	Module 4	<p>Description du module 4</p>	2020-06-13 11:56:10	2020-06-13 11:56:10	\N
+5	Module 5	<p>Description du module 5</p>	2020-06-13 11:56:20	2020-06-13 11:56:20	\N
+6	Module 6	<p>Description du module 6</p>	2020-06-13 11:56:32	2020-06-13 11:56:32	\N
+\.
+
+
+--
+-- Data for Name: application_services; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.application_services (id, description, exposition, name, created_at, updated_at, deleted_at) FROM stdin;
+1	<p>Descrition du service applicatif 1</p>	cloud	SRV-1	2020-06-13 11:35:31	2021-08-03 20:50:33	\N
+2	<p>Description du service 2</p>	local	Service 2	2020-06-13 11:35:48	2020-06-13 11:35:48	\N
+3	<p>Description du service 3</p>	local	Service 3	2020-06-13 11:36:04	2020-06-13 11:43:05	\N
+4	<p>Description du service 4</p>	local	Service 4	2020-06-13 11:36:17	2020-06-13 11:36:17	\N
+5	<p>Service applicatif 4</p>	Extranet	SRV-4	2021-08-02 16:11:43	2021-08-17 10:24:10	\N
+6	<p>Service applicatif 4</p>	\N	SRV-5	2021-08-02 16:12:19	2021-08-02 16:12:19	\N
+7	<p>Service applicatif 4</p>	\N	SRV-6	2021-08-02 16:12:56	2021-08-02 16:12:56	\N
+8	<p>The service 99</p>	local	SRV-99	2021-08-02 16:13:39	2021-09-07 18:53:36	\N
+9	<p>Service applicatif 4</p>	\N	SRV-9	2021-08-02 16:14:27	2021-08-02 16:14:27	\N
+10	<p>Service applicatif 4</p>	Extranet	SRV-10	2021-08-02 16:15:21	2021-08-17 10:24:20	\N
+11	<p>Service applicatif 4</p>	Extranet	SRV-11	2021-08-02 16:16:34	2021-08-17 10:24:28	\N
+\.
+
+
+--
+-- Data for Name: application_module_application_service; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.application_module_application_service (application_service_id, application_module_id) FROM stdin;
+4	1
+4	2
+3	3
+2	4
+1	5
+1	6
+5	2
+5	3
+6	2
+6	3
+7	2
+7	3
+8	2
+8	3
+9	2
+9	3
+10	2
+10	3
+11	2
+11	3
+\.
+
+
+--
+-- Data for Name: entities; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.entities (id, name, security_level, contact_point, description, created_at, updated_at, deleted_at, is_external) FROM stdin;
+1	MegaNet System	<p>ISO 27001</p>	<p>Helpdek<br>27, Rue des poire&nbsp;<br>12043 Mire-en-Mare le Bains</p><p>helpdes@menetsys.org</p>	<p>Fournisseur équipement réseau</p>	2020-05-21 04:30:59	2022-05-20 17:30:00	\N	t
+2	Entité1	<p>Néant</p>	<ul><li>Commercial</li><li>Service Delivery</li><li>Helpdesk</li></ul>	<p>Entité de tests1</p>	2020-05-21 04:31:17	2021-05-23 14:59:11	\N	f
+3	CHdN	3	RSSI du CHdN	<p>Centre Hospitalier du Nord</p>	2020-05-21 04:43:41	2021-05-13 10:20:32	2021-05-13 10:20:32	f
+4	Entité3	<p>ISO 9001</p>	<p>Point de contact de la troisième entité</p>	<p>Description de la troisième entité.</p>	2020-05-21 04:44:03	2021-07-20 21:20:37	\N	f
+5	entité6	<p>Néant</p>	<p>support_informatque@entite6.fr</p>	<p>Description de l'entité six</p>	2020-05-21 04:44:18	2021-05-23 15:03:15	\N	f
+6	Entité4	<p>ISO 27001</p>	<p>Pierre Pinon<br>Tel: 00 34 392 484 22</p>	<p>Description de l'entté quatre</p>	2020-05-21 04:45:14	2021-05-23 15:01:17	\N	f
+7	Entité5	<p>Néant</p>	<p>Servicdesk@entite5.fr</p>	<p>Description de l'entité 5</p>	2020-05-21 05:38:41	2021-05-23 15:02:16	\N	f
+8	Entité2	<p>ISO 27001</p>	<p>Point de contact de l'entité 2</p>	<p>Description de l'entité 2</p>	2020-05-21 05:54:22	2021-05-23 15:00:03	\N	f
+9	NetworkSys	<p>ISO 27001</p>	<p>support@networksys.fr</p>	<p>Description de l’entité NetworkSys</p>	2020-05-21 08:25:15	2022-05-20 17:30:00	\N	t
+10	Agence eSanté	<p>Néant</p>	<p>helpdesk@esante.lu</p>	<p>Agence Nationale des information partagées dans le domaine de la santé</p><ul><li>a</li><li>b</li><li>c</li></ul><p>+-------+<br>+ TOTO +<br>+-------+</p><p>&lt;&lt;&lt;&lt;&lt;&lt; &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;</p>	2020-05-21 08:25:26	2021-05-13 10:20:32	2021-05-13 10:20:32	f
+11	Test	4	\N	<p>Test</p>	2020-07-02 17:37:29	2020-07-02 17:37:44	2020-07-02 17:37:44	f
+12	Pierre et fils	<p>Certifications :&nbsp;<br>- ISO 9001<br>- ISO 27001<br>- ISO 31000</p>	<p>Paul Pierre<br>Gérant<br>00 33 4943 432 423</p>	<p>Description de l'entité de test</p>	2020-07-06 15:37:54	2022-05-20 17:30:00	\N	t
+13	Nestor	<p>Haut niveau</p>	<p>Paul, Pierre et Jean</p>	<p>Description de Nestor</p>	2020-08-12 18:11:31	2020-08-12 18:12:13	\N	f
+14	0001	\N	\N	<p>rrzerze</p>	2021-06-15 17:16:31	2021-06-15 17:17:08	2021-06-15 17:17:08	f
+15	002	\N	\N	<p>sdqsfsd</p>	2021-06-15 17:16:41	2021-06-15 17:17:08	2021-06-15 17:17:08	f
+16	003	\N	\N	<p>dsqdsq</p>	2021-06-15 17:16:51	2021-06-15 17:17:08	2021-06-15 17:17:08	f
+17	004	\N	\N	<p>dqqqsdqs</p>	2021-06-15 17:17:01	2021-06-15 17:17:08	2021-06-15 17:17:08	f
+18	Acme corp.	<p>None sorry...</p>	<p>Do not call me, I will call you back.</p>	<p>Looney tunes academy</p>	2021-09-07 20:07:16	2022-05-20 17:30:00	\N	t
+19	HAL	<p>Top security certification</p>	<p>hal@corp.com</p>	<p>Very big HAL corporation</p>	2021-09-07 20:08:56	2021-09-07 20:09:17	\N	f
+20	ATest1	\N	\N	\N	2022-04-25 14:43:46	2022-04-25 14:44:02	2022-04-25 14:44:02	f
+21	ATest2	\N	\N	\N	2022-04-25 14:43:56	2022-04-25 14:44:02	2022-04-25 14:44:02	f
+\.
+
+
+--
+-- Data for Name: m_applications; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.m_applications (id, name, description, security_need_c, responsible, type, technology, external, users, created_at, updated_at, deleted_at, entity_resp_id, application_block_id, documentation, security_need_i, security_need_a, security_need_t, version, functional_referent, editor, install_date, update_date) FROM stdin;
+1	Application 1	<p>Description de l'application 1</p>	1	RSSI	logiciel	Microsoft	\N	> 20	2020-06-14 11:20:15	2022-03-20 18:53:29	\N	2	3	//Documentation/application1.docx	1	1	1	1.2	\N	\N	\N	\N
+2	Application 2	<p><i>Description</i> de l'<strong>application</strong> 2</p>	2	RSSI	progiciel	martian	SaaS	>100	2020-06-14 11:31:16	2022-02-06 16:52:36	\N	18	1	None	2	2	2	1.0	\N	\N	\N	\N
+3	Application 3	<p>Test application 3</p>	1	RSSI	progiciel	Microsoft	Interne	>100	2020-06-17 19:33:41	2021-05-15 10:06:53	\N	12	2	Aucune	2	3	3	\N	\N	\N	\N	\N
+4	Application 4	<p>Description app4</p>	2	RSSI	logiciel	Microsoft	Internl	>100	2020-08-11 16:13:02	2021-07-11 10:59:57	\N	1	2	None	2	3	2	\N	\N	\N	\N	\N
+5	CUST AP01	<p>Customer appication</p>	0	\N	\N	web	\N	\N	2020-08-22 06:58:18	2020-08-26 16:56:20	2020-08-26 16:56:20	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+6	totototo	\N	0	\N	\N	totottoo	\N	\N	2020-08-22 06:59:26	2020-08-22 06:59:43	2020-08-22 06:59:43	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+7	Windows Word	<p>Description de l'application</p>	3	Nestor	artificiel	client lourd	\N	>100	2020-08-23 10:20:34	2020-08-26 16:56:23	2020-08-26 16:56:23	10	2	\N	\N	\N	\N	\N	\N	\N	\N	\N
+8	Application 99	\N	1	André	progiciel	client lourd	SaaS	>100	2020-08-23 12:08:02	2020-08-26 16:56:13	2020-08-26 16:56:13	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+9	Test33	<p>fsfsdfsd</p>	0	Nestor	progiciel	martian	\N	\N	2020-08-26 16:54:05	2020-08-26 16:54:35	2020-08-26 16:54:35	10	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+10	Test33R	<p>fsfsdfsd</p>	0	Nestor	progiciel	martian	\N	\N	2020-08-26 16:54:28	2020-08-26 16:54:39	2020-08-26 16:54:39	10	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+11	SuperApp	<p>Supper application</p>	0	RSSI	logiciel	martian	\N	\N	2021-04-12 16:54:57	2021-04-12 19:10:44	2021-04-12 19:10:44	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+12	SuperApp	<p>Super super application !</p>	1	RSSI	Web	Oracle	Interne	\N	2021-04-12 19:10:59	2021-06-23 21:33:15	\N	1	2	\N	1	1	1	\N	\N	\N	\N	\N
+13	test application	\N	0	\N	\N	\N	\N	\N	2021-05-07 10:23:59	2021-05-07 10:24:03	2021-05-07 10:24:03	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+14	Windows Calc	<p>Calculatrice windows</p>	2	RSSI	logiciel	Microsoft	Internl	\N	2021-05-13 10:15:27	2022-03-20 18:53:29	\N	1	3	\N	0	0	0	\N	\N	\N	\N	\N
+15	Compta	<p>Application de comptabilité</p>	3	RSSI	progiciel	Microsoft	Interne	>100	2021-05-15 09:53:15	2021-05-15 09:53:15	\N	1	2	\N	4	2	3	\N	\N	\N	\N	\N
+16	Queue Manager	<p>Queue manager</p>	4	RSSI	logiciel	Internal Dev	Interne	>100	2021-08-02 17:17:11	2021-08-02 17:18:32	\N	1	1	//Portal/QueueManager.doc	4	4	4	\N	\N	\N	\N	\N
+17	test	\N	0	\N	\N	\N	\N	\N	2021-10-10 13:03:24	2021-10-10 13:03:24	\N	\N	\N	\N	0	0	0	\N	\N	\N	\N	\N
+18	Application 42	<p>The Ultimate Question of Life, the Universe and Everything</p>	-1	Nestor	\N	\N	\N	\N	2021-11-15 17:03:20	2021-12-11 11:06:18	\N	\N	\N	\N	-1	-1	0	\N	\N	\N	\N	\N
+\.
+
+
+--
+-- Data for Name: application_service_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.application_service_m_application (m_application_id, application_service_id) FROM stdin;
+2	3
+2	4
+1	3
+15	2
+15	3
+1	1
+4	11
+4	5
+2	7
+4	7
+1	10
+16	10
+16	11
+16	5
+16	6
+16	7
+16	9
+16	1
+16	2
+16	3
+16	4
+16	8
+\.
+
+
+--
+-- Data for Name: audit_logs; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.audit_logs (id, description, subject_id, subject_type, user_id, properties, host, created_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: sites; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.sites (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Site A	<p>Description du site A</p>	2020-06-21 06:36:41	2020-06-21 06:36:41	\N
+2	Site B	<p>Description du site B</p>	2020-06-21 06:36:53	2020-06-21 06:36:53	\N
+3	Site C	<p>Description du Site C</p>	2020-06-21 06:37:05	2020-06-21 06:37:05	\N
+4	Test1	<p>site de test</p>	2020-07-24 21:12:29	2020-07-24 21:12:56	2020-07-24 21:12:56
+5	testsite	<p>description here</p>	2021-04-12 17:31:40	2021-04-12 17:32:04	2021-04-12 17:32:04
+6	Site Z	\N	2021-06-18 07:36:03	2021-10-19 18:51:22	2021-10-19 18:51:22
+7	Site 0	\N	2021-06-18 07:36:12	2021-08-17 19:52:52	2021-08-17 19:52:52
+\.
+
+
+--
+-- Data for Name: buildings; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.buildings (id, name, description, created_at, updated_at, deleted_at, site_id, camera, badge) FROM stdin;
+1	Building 1	<p>Description du building 1</p>	2020-06-21 06:37:21	2020-06-21 06:47:41	\N	1	\N	\N
+2	Building 2	<p>Description du building 2</p>	2020-06-21 06:37:36	2020-07-25 08:26:13	\N	1	\N	\N
+3	Building 3	<p>Description du building 3</p>	2020-06-21 06:37:48	2020-07-25 08:26:03	\N	2	\N	\N
+4	Building 4	<p>Description du building 4</p>	2020-06-21 06:38:03	2020-07-25 08:25:54	\N	2	\N	\N
+5	Building 5	<p>Descripion du building 5</p>	2020-06-21 06:38:16	2020-07-25 08:26:26	\N	3	\N	\N
+6	Test building	<p>Description</p>	2020-07-24 21:12:48	2020-07-24 21:14:08	2020-07-24 21:14:08	4	\N	\N
+7	Building 0	<p>Le building zéro</p>	2020-08-21 15:10:15	2020-10-02 09:38:55	\N	1	\N	\N
+8	test	<p>test</p>	2020-11-06 14:44:22	2020-11-06 15:26:18	2020-11-06 15:26:18	\N	t	f
+9	test2	<p>test2</p>	2020-11-06 14:59:45	2020-11-06 15:06:50	2020-11-06 15:06:50	\N	\N	\N
+10	test3	<p>fdfsdfsd</p>	2020-11-06 15:07:07	2020-11-06 15:26:18	2020-11-06 15:26:18	\N	\N	\N
+11	test4	\N	2020-11-06 15:25:52	2020-11-06 15:26:18	2020-11-06 15:26:18	\N	f	f
+\.
+
+
+--
+-- Data for Name: bays; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.bays (id, name, description, created_at, updated_at, deleted_at, room_id) FROM stdin;
+1	BAIE 101	<p>Description de la baie 101</p>	2020-06-21 06:56:01	2021-10-19 18:45:21	\N	7
+2	BAIE 102	<p>Desciption baie 102</p>	2020-06-21 06:56:20	2020-06-21 06:56:20	\N	1
+3	BAIE 103	<p>Descripton baid 103</p>	2020-06-21 06:56:38	2020-06-21 06:56:38	\N	1
+4	BAIE 201	<p>Description baie 201</p>	2020-06-21 06:56:55	2020-06-21 06:56:55	\N	2
+5	BAIE 301	<p>Baie 301</p>	2020-07-15 20:03:07	2020-07-15 20:03:07	\N	3
+6	BAIE 501	<p>Baie 501</p>	2020-07-15 20:10:23	2020-07-15 20:10:23	\N	5
+\.
+
+
+--
+-- Data for Name: wifi_terminals; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.wifi_terminals (id, name, description, type, created_at, updated_at, deleted_at, site_id, building_id) FROM stdin;
+1	WIFI_01	<p>Borne wifi 01</p>	Alcatel 3500	2020-07-22 16:44:37	2020-07-22 16:44:37	\N	1	2
+2	WIFI_02	<p>Borne Wifi 2</p>	ALCALSYS 3001	2021-06-07 16:37:47	2021-06-07 16:37:47	\N	2	1
+3	WIFI_03	<p>Borne Wifi 3</p>	SYSTEL 3310	2021-06-07 16:42:29	2021-06-07 16:43:18	\N	3	4
+\.
+
+
+--
+-- Data for Name: bay_wifi_terminal; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.bay_wifi_terminal (wifi_terminal_id, bay_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: cartographer_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.cartographer_m_application (id, user_id, m_application_id, created_at, updated_at, deleted_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: certificates; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.certificates (id, name, type, description, start_validity, end_validity, created_at, updated_at, deleted_at, status) FROM stdin;
+1	CERT01	DES3	<p>Certificat 01</p>	2020-10-27	2022-01-01	2021-07-14 10:28:47	2022-02-08 16:25:10	\N	0
+2	CERT02	AES 256	<p>Certificat numéro 02</p>	2021-07-14	2021-07-17	2021-07-14 10:33:33	2021-07-14 16:14:12	\N	\N
+3	CERT03	AES 256	<p>Certificat numéro 3</p>	2021-09-23	2021-11-11	2021-07-14 12:35:41	2021-09-23 16:11:34	\N	\N
+4	CERT04	DES3	<p>Certificat interne DES 3</p>	\N	\N	2021-07-14 12:40:15	2021-07-14 12:40:15	\N	\N
+5	CERT05	RSA 128	<p>Clé 05 avec RSA</p>	\N	\N	2021-07-14 12:45:00	2021-07-14 12:45:00	\N	\N
+6	CERT07	DES3	<p>cert 7</p>	\N	\N	2021-07-14 14:44:12	2021-07-14 14:44:12	\N	\N
+7	CERT08	DES3	<p>Master cert 08</p>	2021-06-15	2022-08-11	2021-08-11 20:33:42	2021-08-11 20:33:42	\N	\N
+8	CERT09	DES3	<p>Test cert nine</p>	2021-09-25	2021-09-26	2021-09-23 16:17:20	2021-09-23 16:17:20	\N	\N
+\.
+
+
+--
+-- Data for Name: logical_servers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.logical_servers (id, name, description, net_services, configuration, created_at, updated_at, deleted_at, operating_system, address_ip, cpu, memory, environment, disk, install_date, update_date) FROM stdin;
+1	SRV-1	<p>Description du serveur 1</p>	DNS, HTTP, HTTPS	<p>Configuration du serveur 1</p>	2020-07-12 18:57:42	2021-08-17 15:13:21	\N	Windows 3.1	10.10.1.1, 10.10.10.1	2	8	PROD	60	\N	\N
+2	SRV-2	<p>Description du serveur 2</p>	HTTPS, SSH	<p>Configuration par défaut</p>	2020-07-30 12:00:16	2021-08-17 20:17:41	\N	Windows 10	10.50.1.2	2	5	PROD	100	\N	\N
+3	SRV-3	<p>Description du serveur 3</p>	HTTP, HTTPS	\N	2021-08-26 16:33:03	2021-08-26 16:33:38	\N	Ubuntu 20.04	10.70.8.3	4	16	PROD	80	\N	\N
+4	SRV-42	<p><i>The Ultimate Question of Life, the Universe and Everything</i></p>	\N	<p>Full configuration</p>	2021-11-15 17:03:59	2022-03-20 12:39:54	\N	OS 42	10.0.0.42	42	42 G	PROD	42	\N	\N
+5	SRV-4	<p>Description du serveur 4</p>	\N	\N	2022-05-02 18:43:02	2022-05-02 18:49:34	\N	Ubunti 22.04 LTS	10.10.3.2	4	2	Dev	\N	2022-05-01 20:47:41	2022-05-02 20:47:47
+\.
+
+
+--
+-- Data for Name: certificate_logical_server; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.certificate_logical_server (certificate_id, logical_server_id) FROM stdin;
+4	1
+5	2
+1	1
+2	1
+3	1
+7	1
+\.
+
+
+--
+-- Data for Name: certificate_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.certificate_m_application (certificate_id, m_application_id) FROM stdin;
+8	4
+\.
+
+
+--
+-- Data for Name: databases; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.databases (id, name, description, responsible, type, security_need_c, external, created_at, updated_at, deleted_at, entity_resp_id, security_need_i, security_need_a, security_need_t) FROM stdin;
+1	Database 1	<p>Description Database 1</p>	Paul	MySQL	1	Interne	2020-06-17 16:18:48	2021-05-14 12:19:45	\N	2	2	3	4
+3	Database 2	<p>Description database 2</p>	Paul	MySQL	1	Interne	2020-06-17 16:19:24	2021-05-14 12:29:47	\N	1	1	1	1
+4	MainDB	<p>description de la base de données</p>	Paul	Oracle	2	Interne	2020-07-01 17:08:57	2021-08-20 03:52:23	\N	1	2	2	2
+5	DB Compta	<p>Base de donnée de la compta</p>	Paul	MariaDB	2	Interne	2020-08-24 17:58:23	2022-03-21 18:13:10	\N	18	2	2	2
+6	Data Warehouse	<p>Base de données du datawarehouse</p>	Jean	Oracle	2	Interne	2021-05-14 12:24:02	2022-03-21 18:13:24	\N	1	2	2	2
+\.
+
+
+--
+-- Data for Name: database_entity; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.database_entity (database_id, entity_id) FROM stdin;
+1	1
+3	1
+4	1
+5	1
+6	1
+\.
+
+
+--
+-- Data for Name: information; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.information (id, name, description, owner, administrator, storage, security_need_c, sensitivity, constraints, created_at, updated_at, deleted_at, security_need_i, security_need_a, security_need_t) FROM stdin;
+1	Information 1	<p>Description de l'information 1</p>	Luc	\N	externe	1	Donnée à caractère personnel	<p>Description des contraintes règlementaires et normatives</p>	2020-06-13 02:06:43	2021-11-04 08:43:27	\N	3	2	2
+2	information 2	<p>Description de l'information</p>	Nestor	Nom de l'administrateur	externe	2	Donnée à caractère personnel	\N	2020-06-13 02:09:13	2021-08-19 18:42:53	\N	1	1	1
+3	information 3	<p>Descripton de l'information 3</p>	Paul	Jean	Local	4	Donnée à caractère personnel	\N	2020-06-13 02:10:07	2021-09-28 19:42:07	\N	4	3	4
+4	Information de test	<p>decription du test</p>	RSSI	Paul	Local	1	Technical	\N	2020-07-01 17:00:37	2021-08-19 18:45:52	\N	1	1	1
+5	Données du client	<p>Données d'identification du client</p>	Nestor	Paul	Local	2	Donnée à caractère personnel	<p>RGPD</p>	2021-05-14 12:50:09	2022-03-21 18:12:30	\N	2	2	2
+\.
+
+
+--
+-- Data for Name: database_information; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.database_information (database_id, information_id) FROM stdin;
+1	1
+1	2
+1	3
+3	2
+3	3
+5	1
+4	2
+6	2
+6	3
+5	5
+\.
+
+
+--
+-- Data for Name: database_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.database_m_application (m_application_id, database_id) FROM stdin;
+2	3
+3	4
+3	1
+4	5
+4	6
+15	5
+15	4
+16	1
+\.
+
+
+--
+-- Data for Name: dhcp_servers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.dhcp_servers (id, name, description, created_at, updated_at, deleted_at, address_ip) FROM stdin;
+\.
+
+
+--
+-- Data for Name: dnsservers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.dnsservers (id, name, description, created_at, updated_at, deleted_at, address_ip) FROM stdin;
+\.
+
+
+--
+-- Data for Name: domaine_ads; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.domaine_ads (id, name, description, domain_ctrl_cnt, user_count, machine_count, relation_inter_domaine, created_at, updated_at, deleted_at) FROM stdin;
+1	Dom1	<p>Domaine AD1</p>	3	2000	800	Non	2020-07-03 09:51:06	2020-07-03 09:51:06	\N
+2	test domain	<p>this is a test</p>	\N	\N	\N	\N	2021-05-27 15:24:52	2021-05-27 15:29:15	2021-05-27 15:29:15
+3	Dom2	<p>Second domaine active directory</p>	2	100	1	Néant	2021-05-27 15:29:43	2021-05-27 15:29:43	\N
+4	Dom5	<p>Domaine cinq</p>	\N	\N	\N	\N	2021-05-27 15:39:08	2021-05-27 15:39:08	\N
+5	Dom4	<p>Domaine quatre</p>	\N	\N	\N	\N	2021-05-27 15:39:20	2021-05-27 15:39:20	\N
+\.
+
+
+--
+-- Data for Name: forest_ads; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.forest_ads (id, name, description, created_at, updated_at, deleted_at, zone_admin_id) FROM stdin;
+1	AD1	<p>Foret de l'AD 1</p>	2020-07-03 09:50:07	2020-07-03 09:50:29	\N	1
+2	AD2	<p>Foret de l'AD2</p>	2020-07-03 09:50:19	2020-07-03 09:50:19	\N	1
+\.
+
+
+--
+-- Data for Name: domaine_ad_forest_ad; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.domaine_ad_forest_ad (forest_ad_id, domaine_ad_id) FROM stdin;
+1	1
+2	1
+1	3
+2	5
+1	4
+\.
+
+
+--
+-- Data for Name: entity_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.entity_m_application (m_application_id, entity_id) FROM stdin;
+2	1
+5	1
+7	2
+9	1
+10	1
+2	2
+11	1
+1	2
+1	8
+3	8
+4	8
+4	4
+16	2
+\.
+
+
+--
+-- Data for Name: entity_process; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.entity_process (process_id, entity_id) FROM stdin;
+1	1
+2	1
+3	1
+1	13
+3	13
+4	1
+7	3
+9	4
+2	8
+4	6
+4	7
+9	5
+1	9
+2	9
+3	9
+4	9
+9	9
+1	12
+1	2
+4	18
+3	19
+\.
+
+
+--
+-- Data for Name: external_connected_entities; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.external_connected_entities (id, name, responsible_sec, contacts, created_at, updated_at, deleted_at) FROM stdin;
+1	Entité externe 1	Nestor	Marcel	2020-07-23 09:59:25	2020-07-23 09:59:25	\N
+2	Entité externe 2	Philippe	it@external.corp	2021-08-17 19:52:26	2021-08-17 19:52:26	\N
+\.
+
+
+--
+-- Data for Name: networks; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.networks (id, name, protocol_type, responsible, responsible_sec, security_need_c, description, created_at, updated_at, deleted_at, security_need_i, security_need_a, security_need_t) FROM stdin;
+1	Réseau 1	TCP	Pierre	Paul	1	<p>Description du réseau 1</p>	2020-06-23 14:34:14	2021-09-22 12:20:11	\N	2	3	4
+2	Réseau 2	TCP	Johan	Jean-Marc	1	<p>Description du réseau 2</p>	2020-07-01 17:45:41	2021-09-22 12:21:23	\N	1	1	1
+3	test	\N	\N	\N	4	<p>réseau test</p>	2021-09-22 12:30:23	2021-09-22 12:30:29	2021-09-22 12:30:29	4	4	4
+\.
+
+
+--
+-- Data for Name: external_connected_entity_network; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.external_connected_entity_network (external_connected_entity_id, network_id) FROM stdin;
+1	1
+2	2
+\.
+
+
+--
+-- Data for Name: fluxes; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.fluxes (id, name, description, created_at, updated_at, deleted_at, application_source_id, service_source_id, module_source_id, database_source_id, application_dest_id, service_dest_id, module_dest_id, database_dest_id, crypted, bidirectional) FROM stdin;
+2	FluxA	<p>Description du flux A</p>	2020-06-17 16:50:59	2021-09-29 08:02:26	\N	1	\N	\N	\N	2	\N	\N	\N	f	t
+3	FluxC	<p>Flux de test</p>	2020-07-07 15:58:22	2021-09-23 19:04:30	\N	2	\N	\N	\N	3	\N	\N	\N	t	\N
+4	FluxB	<p>Flux de test 3</p>	2020-07-07 16:01:10	2021-09-29 08:07:54	\N	\N	\N	4	\N	2	\N	\N	\N	t	t
+5	Sync_DB	<p>Description du flux 01</p>	2020-07-23 12:44:35	2021-10-10 13:16:32	\N	\N	\N	\N	\N	\N	\N	\N	3	t	f
+6	Flux_MOD_01	<p>Fuld module</p>	2020-07-23 12:48:20	2021-09-29 07:59:35	\N	\N	\N	3	\N	\N	\N	2	\N	f	f
+7	Flux_SER_01	Description du flux service 01	2020-07-23 12:51:41	2020-07-23 12:51:41	\N	\N	3	\N	\N	\N	4	\N	\N	f	\N
+8	Fulx 07	Description du flux 07	2020-09-05 06:56:57	2020-09-05 06:57:36	\N	\N	1	\N	\N	\N	2	\N	\N	t	\N
+9	FLux DB_02	<p>Description du flux 2</p>	2020-09-05 07:12:05	2021-09-29 07:59:19	\N	2	\N	\N	\N	\N	\N	2	\N	f	f
+10	SRV10_to_SRV11	<p>Transfert from SRV10 to SRV11</p>	2021-08-02 17:13:31	2021-08-02 17:13:31	\N	\N	10	\N	\N	\N	11	\N	\N	f	\N
+11	SRV4_to_SRV10	\N	2021-08-02 17:13:57	2021-08-02 17:13:57	\N	\N	5	\N	\N	\N	10	\N	\N	t	\N
+12	SRV6_to_SRV10	<p>service 6 to service 10</p>	2021-08-02 17:14:36	2021-08-02 17:14:36	\N	\N	7	\N	\N	\N	10	\N	\N	t	\N
+13	Syncy System	\N	2021-08-02 20:01:21	2021-08-02 20:01:21	\N	\N	10	\N	\N	\N	\N	\N	\N	t	\N
+14	00001	\N	2021-09-01 09:00:09	2021-09-01 09:00:21	2021-09-01 09:00:21	\N	\N	\N	\N	\N	\N	\N	\N	t	\N
+15	0002	\N	2021-09-01 09:00:15	2021-09-01 09:00:21	2021-09-01 09:00:21	\N	\N	\N	\N	\N	\N	\N	\N	t	\N
+\.
+
+
+--
+-- Data for Name: gateways; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.gateways (id, name, description, ip, authentification, created_at, updated_at, deleted_at) FROM stdin;
+1	GW01	<p>Gateway 01 vers réseau médor</p>	123.5.6.4/12	Carte à puce	2020-07-13 19:34:45	2020-07-13 19:34:45	\N
+2	Workspace One	<p>Test workspace One</p>	10.10.10.1	Token	2021-04-17 21:32:57	2021-04-17 21:40:31	2021-04-17 21:40:31
+3	PubicGW	<p>Public Gateway</p>	10.10.10.1	Token	2021-04-17 21:39:04	2021-04-17 21:40:25	2021-04-17 21:40:25
+4	PublicGW	<p>Public gateway</p>	8.8.8.8	Token	2021-04-17 21:40:48	2021-04-17 21:48:34	\N
+5	GW02	<p>Second gateway</p>	\N	Token	2021-05-18 20:27:13	2021-08-18 20:04:23	\N
+\.
+
+
+--
+-- Data for Name: information_process; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.information_process (information_id, process_id) FROM stdin;
+3	2
+4	3
+4	4
+4	1
+1	4
+2	9
+5	1
+5	2
+5	4
+5	9
+\.
+
+
+--
+-- Data for Name: lans; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.lans (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	LAN_1	Lan principal	2020-07-22 07:42:00	2020-07-22 07:42:00	\N
+2	LAN_2	Second LAN	2021-06-23 21:19:38	2021-06-23 21:19:38	\N
+3	LAN_0	Lan zero	2021-06-23 21:20:04	2021-06-23 21:20:04	\N
+\.
+
+
+--
+-- Data for Name: mans; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.mans (id, name, created_at, updated_at, deleted_at) FROM stdin;
+1	MAN_1	2020-08-22 06:17:20	2020-08-22 06:17:20	\N
+2	MAN_2	2021-05-07 10:14:27	2021-05-07 10:23:23	\N
+3	Test1	2022-04-25 14:43:02	2022-04-25 14:52:49	2022-04-25 14:52:49
+4	Test2	2022-04-25 14:43:09	2022-04-25 14:52:49	2022-04-25 14:52:49
+\.
+
+
+--
+-- Data for Name: lan_man; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.lan_man (man_id, lan_id) FROM stdin;
+1	1
+2	1
+2	2
+2	3
+\.
+
+
+--
+-- Data for Name: wans; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.wans (id, name, created_at, updated_at, deleted_at) FROM stdin;
+1	WAN01	2021-05-21 12:58:42	2021-05-21 12:58:42	\N
+\.
+
+
+--
+-- Data for Name: lan_wan; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.lan_wan (wan_id, lan_id) FROM stdin;
+1	1
+\.
+
+
+--
+-- Data for Name: logical_server_m_application; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.logical_server_m_application (m_application_id, logical_server_id) FROM stdin;
+2	1
+2	2
+3	2
+1	1
+18	4
+15	3
+4	2
+4	5
+\.
+
+
+--
+-- Data for Name: physical_switches; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.physical_switches (id, name, description, type, created_at, updated_at, deleted_at, site_id, building_id, bay_id) FROM stdin;
+1	Switch de test	<p>Master test switch.</p>	Nortel A39	2020-07-17 15:29:09	2022-04-25 18:22:02	\N	1	2	4
+2	Switch 2	<p>Description switch 2</p>	Alcatel 430	2020-07-17 15:31:41	2020-07-17 15:31:41	\N	1	1	1
+3	Switch 1	<p>Desription du premier switch.</p>	Nortel 2300	2020-07-25 07:27:27	2022-04-25 14:55:06	\N	2	3	5
+4	Switch 3	<p>Desciption du switch 3</p>	Alcatel 3500	2020-07-25 09:42:51	2020-07-25 09:43:21	\N	3	5	6
+5	AB	<p>Test 2 chars switch</p>	\N	2020-08-22 06:19:45	2020-08-27 18:04:20	2020-08-27 18:04:20	\N	\N	\N
+\.
+
+
+--
+-- Data for Name: physical_servers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.physical_servers (id, name, description, responsible, configuration, created_at, updated_at, deleted_at, site_id, building_id, bay_id, physical_switch_id, type) FROM stdin;
+1	Serveur A1	<p>Description du serveur A1</p>	Marc	<p>OS: OS2<br>IP : 127.0.0.1<br>&nbsp;</p>	2020-06-21 07:27:02	2021-11-27 12:12:00	\N	1	2	4	\N	System 840
+2	Serveur A2	<p>Description du serveur A2</p>	Marc	<p>Configuration du serveur A<br>OS : Linux 23.4<br>RAM: 32G</p>	2020-06-21 07:27:58	2021-11-27 12:12:12	\N	3	5	6	\N	System 840
+3	Serveur A3	<p>Serveur mobile</p>	Marc	<p>None</p>	2020-07-14 17:30:48	2021-11-27 12:12:24	\N	1	1	3	\N	System 840
+4	ZZ99	<p>Zoro server</p>	\N	\N	2020-07-14 17:37:50	2020-08-25 16:54:58	2020-08-25 16:54:58	3	5	\N	\N	\N
+5	K01	<p>Serveur K01</p>	\N	<p>TOP CPU<br>TOP RAM</p>	2020-07-15 16:37:04	2020-08-29 14:08:09	2020-08-29 14:08:09	1	1	3	\N	\N
+6	Mainframe 01	<p>Central accounting system</p>	Marc	<p>40G RAM<br>360P Disk<br>CICS / Cobol</p>	2020-09-05 10:02:49	2021-11-27 12:11:43	\N	1	1	1	2	Type 404
+7	Mainframe T1	<p>Mainframe de test</p>	Marc	<p>IDEM prod</p>	2020-09-05 10:22:18	2021-11-27 12:11:01	\N	2	3	4	2	HAL 340
+8	Serveur A4	<p>Departmental server</p>	Marc	<p>Standard configuration</p>	2021-06-22 17:34:33	2021-11-27 12:12:50	\N	2	3	5	\N	Mini 900/2
+\.
+
+
+--
+-- Data for Name: logical_server_physical_server; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.logical_server_physical_server (logical_server_id, physical_server_id) FROM stdin;
+2	1
+2	2
+1	1
+1	7
+3	8
+4	7
+5	8
+\.
+
+
+--
+-- Data for Name: m_application_events; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.m_application_events (id, user_id, m_application_id, message, created_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: m_application_process; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.m_application_process (m_application_id, process_id) FROM stdin;
+2	1
+2	2
+3	2
+1	1
+14	2
+4	3
+12	4
+16	1
+16	2
+16	3
+16	4
+16	9
+\.
+
+
+--
+-- Data for Name: man_wan; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.man_wan (wan_id, man_id) FROM stdin;
+1	1
+\.
+
+
+--
+-- Data for Name: media; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.media (id, model_type, model_id, collection_name, name, file_name, mime_type, disk, size, manipulations, custom_properties, responsive_images, order_column, created_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: network_switches; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.network_switches (id, name, ip, description, created_at, updated_at, deleted_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: oauth_access_tokens; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.oauth_access_tokens (id, user_id, client_id, name, scopes, revoked, created_at, updated_at, expires_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: oauth_auth_codes; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.oauth_auth_codes (id, user_id, client_id, scopes, revoked, expires_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: oauth_clients; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.oauth_clients (id, user_id, name, secret, provider, redirect, personal_access_client, password_client, revoked, created_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: oauth_personal_access_clients; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.oauth_personal_access_clients (id, client_id, created_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: oauth_refresh_tokens; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.oauth_refresh_tokens (id, access_token_id, revoked, expires_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: tasks; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.tasks (id, nom, description, created_at, updated_at, deleted_at) FROM stdin;
+1	Tâche 2	Descriptionde la tâche 2	2020-06-13 02:04:07	2020-06-13 02:04:07	\N
+2	Tache 1	Description de la tâche 1	2020-06-13 02:04:21	2020-06-13 02:04:21	\N
+3	Tâche 3	Description de la tâche 3	2020-06-13 02:04:41	2020-06-13 02:04:41	\N
+\.
+
+
+--
+-- Data for Name: operation_task; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.operation_task (operation_id, task_id) FROM stdin;
+1	1
+1	2
+2	1
+3	3
+4	2
+5	1
+5	2
+5	3
+\.
+
+
+--
+-- Data for Name: password_resets; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.password_resets (email, token, created_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: peripherals; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.peripherals (id, name, type, description, responsible, created_at, updated_at, deleted_at, site_id, building_id, bay_id) FROM stdin;
+1	PER_01	IBM 3400	<p>important peripheral</p>	Marcel	2020-07-25 08:18:40	2020-07-25 08:19:46	\N	1	2	\N
+2	PER_02	IBM 5600	<p>Description</p>	Nestor	2020-07-25 08:19:18	2020-07-25 08:19:18	\N	3	5	\N
+3	PER_03	HAL 8100	<p>Space device</p>	Niel	2020-07-25 08:19:58	2020-07-25 08:20:18	\N	3	4	\N
+\.
+
+
+--
+-- Data for Name: phones; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.phones (id, name, description, type, created_at, updated_at, deleted_at, site_id, building_id, physical_switch_id) FROM stdin;
+1	Phone 01	<p>Téléphone de test</p>	MOTOROAL 3110	2020-07-21 07:16:46	2020-07-25 09:15:17	\N	1	1	\N
+2	Phone 03	<p>Special AA phone</p>	Top secret red phne	2020-07-21 07:18:01	2020-07-25 09:25:38	\N	2	4	\N
+3	Phone 02	<p>Description phone 02</p>	IPhone 2	2020-07-25 08:52:23	2020-07-25 09:25:19	\N	2	3	\N
+\.
+
+
+--
+-- Data for Name: physical_routers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.physical_routers (id, description, type, created_at, updated_at, deleted_at, site_id, building_id, bay_id, name) FROM stdin;
+1	<p>Routeur prncipal</p>	Fortinet	2020-07-10 08:58:53	2021-10-12 21:08:21	\N	1	1	1	R1
+2	<p>Routeur secondaire</p>	CISCO	2020-07-10 09:19:11	2020-07-25 10:28:17	\N	2	3	5	R2
+\.
+
+
+--
+-- Data for Name: vlans; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.vlans (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+1	VLAN_2	VLAN Wifi	2020-07-07 16:31:53	2020-07-07 16:39:10	\N
+2	VLAN_1	VLAN publc	2020-07-07 16:34:30	2020-07-07 16:38:53	\N
+3	VLAN_3	VLAN application	2020-07-07 16:38:41	2020-07-08 21:35:53	\N
+4	VLAN_4	Vlan Client	2020-07-08 21:34:11	2020-07-08 21:36:06	\N
+5	VLAN_5	Test Production	2020-07-11 19:12:03	2021-08-18 19:35:54	\N
+6	VLAN_6	VLAN démilitarisé	2020-07-11 19:14:55	2021-08-18 19:36:12	\N
+7	VLAN_7	Description du VLAN 7	2021-09-07 18:35:28	2021-09-07 18:35:28	\N
+8	VLAN_8	Description du VLAN 8	2021-09-07 18:36:20	2021-09-07 18:36:20	\N
+\.
+
+
+--
+-- Data for Name: physical_router_vlan; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.physical_router_vlan (physical_router_id, vlan_id) FROM stdin;
+1	1
+1	3
+2	3
+\.
+
+
+--
+-- Data for Name: physical_security_devices; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.physical_security_devices (id, name, type, description, created_at, updated_at, deleted_at, site_id, building_id, bay_id) FROM stdin;
+1	Magic Gate	Gate	<p>BIG Magic Gate</p>	2021-05-20 16:40:43	2021-11-13 21:29:45	\N	1	1	1
+2	Magic Firewall	Firewall	<p>The magic firewall - PT3743</p>	2021-06-07 16:56:26	2021-11-13 21:29:32	\N	2	3	5
+3	Sensor-1	Sensor	<p>Temperature sensor</p>	2021-11-13 21:37:14	2021-11-13 21:37:56	\N	1	3	\N
+\.
+
+
+--
+-- Data for Name: relations; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.relations (id, importance, name, type, description, created_at, updated_at, deleted_at, source_id, destination_id) FROM stdin;
+1	1	Membre	Fourniture de service	<p>Here is the description of this relation</p>	2020-05-21 00:49:47	2021-08-17 10:20:46	\N	1	6
+2	2	Membre	Fournisseur de service	<p>Member description</p>	2020-05-21 01:35:11	2021-09-19 13:12:19	\N	2	6
+3	1	Fournisseur	Fournisseur de service	<p>description de la relation entre A et le B</p>	2020-05-21 01:39:24	2021-08-17 10:20:59	\N	7	1
+4	2	Membre	Fourniture de service	<p>Description du service</p>	2020-05-21 04:23:03	2021-05-23 15:06:05	\N	2	6
+5	0	Membre	Fournisseur de service	\N	2020-05-21 04:23:35	2021-05-23 15:05:18	\N	2	6
+6	0	Fournisseur	fourniture de service	\N	2020-05-21 04:24:35	2020-05-21 04:24:35	\N	7	2
+7	0	Membre	fourniture de service	\N	2020-05-21 04:26:43	2020-05-21 04:26:43	\N	4	6
+8	3	Rapporte	\N	\N	2020-05-21 04:32:19	2020-07-05 12:10:01	\N	1	5
+9	0	Fournisseur	fourniture de service	\N	2020-05-21 04:33:33	2020-05-21 04:33:33	\N	9	1
+10	2	Rapporte	Fournisseur de service	<p>Régelement général APD34</p>	2020-05-22 23:21:02	2020-08-24 16:31:29	\N	1	8
+11	2	toto	\N	\N	2020-07-05 12:14:15	2020-07-05 12:14:55	2020-07-05 12:14:55	3	2
+12	1	Fournisseur	Fournisseur de service	<p>Analyse de risques</p>	2020-08-24 16:23:30	2020-08-24 16:23:48	\N	2	4
+13	1	Fournisseur	Fourniture de service	<p>Description du service</p>	2020-10-14 19:06:24	2021-05-23 15:06:34	\N	2	12
+\.
+
+
+--
+-- Data for Name: routers; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.routers (id, name, description, rules, created_at, updated_at, deleted_at, ip_addresses) FROM stdin;
+\.
+
+
+--
+-- Data for Name: security_devices; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.security_devices (id, name, description, created_at, updated_at, deleted_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: storage_devices; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.storage_devices (id, name, description, created_at, updated_at, deleted_at, site_id, building_id, bay_id, physical_switch_id) FROM stdin;
+1	DiskServer 1	<p>Description du serveur d stockage 1</p>	2020-06-21 17:30:16	2020-06-21 17:30:16	\N	1	2	3	\N
+2	Oracle Server	<p>Main oracle server</p>	2020-06-21 17:33:51	2020-06-21 17:34:38	\N	1	2	2	\N
+\.
+
+
+--
+-- Data for Name: subnetworks; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.subnetworks (id, description, address, ip_allocation_type, responsible_exp, dmz, wifi, name, created_at, updated_at, deleted_at, connected_subnets_id, gateway_id, zone, vlan_id, network_id, default_gateway) FROM stdin;
+1	<p>Description du sous-réseau 1</p>	10.10.0.0 /16	Static	Marc	non	non	Subnet1	2020-06-23 14:35:41	2021-11-16 21:24:29	\N	\N	1	ZONE_ACCUEIL	2	1	10.10.0.1
+2	<p>Description du subnet 2</p>	10.20.0.0/16	Static	Henri	Oui	Oui	Subnet2	2020-07-04 09:35:10	2021-09-21 16:52:35	\N	\N	5	ZONE_WORK	1	1	10.20.0.1
+3	<p>Description du quatrième subnet</p>	10.40.0.0/16	Static	Jean	non	non	Subnet4	2020-11-06 13:56:33	2021-08-20 09:56:50	\N	2	5	ZONE_WORK	4	1	10.40.0.1
+4	<p>descrption subnet 3</p>	8.8.8.8 /  255.255.255.0	\N	\N	\N	\N	test subnet 3	2021-02-24 12:49:16	2021-02-24 12:49:33	2021-02-24 12:49:33	\N	\N	\N	\N	\N	\N
+5	<p>Troisième sous-réseau</p>	10.30.0.0/16	Static	Jean	non	non	Subnet3	2021-05-19 16:48:39	2021-08-20 09:57:01	\N	\N	1	ZONE_WORK	3	1	10.30.0.1
+6	<p>Description du cinquième réseau</p>	10.50.0.0/16	Fixed	Jean	Oui	non	Subnet5	2021-08-17 13:35:28	2021-08-26 17:27:41	\N	\N	1	ZONE_BACKUP	5	1	10.50.0.1
+7	<p>Description du sixième sous-réseau</p>	10.60.0.0/16	Fixed	Jean	non	non	Subnet6	2021-08-17 18:32:47	2021-08-26 17:27:57	\N	2	4	ZONE_APP	6	2	10.60.1.1
+8	<p>Test</p>	\N	\N	\N	\N	\N	Subnet7	2021-08-18 18:05:50	2021-08-18 18:10:19	2021-08-18 18:10:19	\N	\N	\N	\N	\N	\N
+9	<p>Sous-réseau numéro sept</p>	10.70.0.0/16	Static	Jean	Oui	Oui	Subnet7	2021-08-18 18:11:10	2021-08-26 17:27:30	\N	\N	\N	ZONE_BACKUP	5	2	10.70.0.1
+10	<p>Sous réseau démilitarisé</p>	10.70.0.0/32	Fixed	Jean	Oui	non	Subnet8	2021-08-18 18:33:48	2021-08-26 17:28:10	\N	\N	1	ZONE_DMZ	7	1	10.70.0.1
+11	<p>Description subnet 9</p>	10.90.0.0/32	\N	Jean	non	non	Subnet9	2021-09-07 18:41:02	2021-09-07 18:41:02	\N	\N	\N	ZONE_DATA	8	1	10.90.1.1
+\.
+
+
+--
+-- Data for Name: workstations; Type: TABLE DATA; Schema: public; Owner: jfc
+--
+
+COPY public.workstations (id, name, description, created_at, updated_at, deleted_at, site_id, building_id, physical_switch_id, type) FROM stdin;
+1	Workstation 1	<p>Station de travail compta</p>	2020-06-21 17:09:04	2022-03-20 12:37:13	\N	1	7	\N	ThinThink 460
+2	Workstation 2	<p>Station de travail accueil</p>	2020-06-21 17:09:54	2021-10-20 09:14:59	\N	2	3	\N	ThinThink 410
+3	Workstation 3	<p>Station de travail back-office</p>	2020-06-21 17:17:57	2021-10-20 09:15:25	\N	2	4	\N	ThinThink 420
+\.
+
+
+--
+-- Name: activities_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.activities_id_seq', 1, false);
+
+
+--
+-- Name: actors_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.actors_id_seq', 1, false);
+
+
+--
+-- Name: annuaires_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.annuaires_id_seq', 1, false);
+
+
+--
+-- Name: application_blocks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.application_blocks_id_seq', 1, false);
+
+
+--
+-- Name: application_modules_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.application_modules_id_seq', 1, false);
+
+
+--
+-- Name: application_services_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.application_services_id_seq', 1, false);
+
+
+--
+-- Name: audit_logs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.audit_logs_id_seq', 1, false);
+
+
+--
+-- Name: bays_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.bays_id_seq', 1, false);
+
+
+--
+-- Name: buildings_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.buildings_id_seq', 1, false);
+
+
+--
+-- Name: cartographer_m_application_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.cartographer_m_application_id_seq', 1, false);
+
+
+--
+-- Name: certificates_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.certificates_id_seq', 1, false);
+
+
+--
+-- Name: databases_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.databases_id_seq', 1, false);
+
+
+--
+-- Name: dhcp_servers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.dhcp_servers_id_seq', 1, false);
+
+
+--
+-- Name: dnsservers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.dnsservers_id_seq', 1, false);
+
+
+--
+-- Name: domaine_ads_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.domaine_ads_id_seq', 1, false);
+
+
+--
+-- Name: entities_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.entities_id_seq', 1, false);
+
+
+--
+-- Name: external_connected_entities_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.external_connected_entities_id_seq', 1, false);
+
+
+--
+-- Name: fluxes_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.fluxes_id_seq', 1, false);
+
+
+--
+-- Name: forest_ads_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.forest_ads_id_seq', 1, false);
+
+
+--
+-- Name: gateways_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.gateways_id_seq', 1, false);
+
+
+--
+-- Name: information_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.information_id_seq', 1, false);
+
+
+--
+-- Name: lans_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.lans_id_seq', 1, false);
+
+
+--
+-- Name: logical_servers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.logical_servers_id_seq', 1, false);
+
+
+--
+-- Name: m_application_events_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.m_application_events_id_seq', 1, false);
+
+
+--
+-- Name: m_applications_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.m_applications_id_seq', 1, false);
+
+
+--
+-- Name: macro_processuses_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.macro_processuses_id_seq', 1, false);
+
+
+--
+-- Name: mans_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.mans_id_seq', 1, false);
+
+
+--
+-- Name: media_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.media_id_seq', 1, false);
+
+
+--
+-- Name: migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.migrations_id_seq', 150, true);
+
+
+--
+-- Name: network_switches_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.network_switches_id_seq', 1, false);
+
+
+--
+-- Name: networks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.networks_id_seq', 1, false);
+
+
+--
+-- Name: oauth_clients_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.oauth_clients_id_seq', 1, false);
+
+
+--
+-- Name: oauth_personal_access_clients_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.oauth_personal_access_clients_id_seq', 1, false);
+
+
+--
+-- Name: operations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.operations_id_seq', 1, false);
+
+
+--
+-- Name: peripherals_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.peripherals_id_seq', 1, false);
+
+
+--
+-- Name: permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.permissions_id_seq', 1, false);
+
+
+--
+-- Name: phones_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.phones_id_seq', 1, false);
+
+
+--
+-- Name: physical_routers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.physical_routers_id_seq', 1, false);
+
+
+--
+-- Name: physical_security_devices_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.physical_security_devices_id_seq', 1, false);
+
+
+--
+-- Name: physical_servers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.physical_servers_id_seq', 1, false);
+
+
+--
+-- Name: physical_switches_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.physical_switches_id_seq', 1, false);
+
+
+--
+-- Name: processes_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.processes_id_seq', 1, false);
+
+
+--
+-- Name: relations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.relations_id_seq', 1, false);
+
+
+--
+-- Name: roles_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.roles_id_seq', 1, false);
+
+
+--
+-- Name: routers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.routers_id_seq', 1, false);
+
+
+--
+-- Name: security_devices_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.security_devices_id_seq', 1, false);
+
+
+--
+-- Name: sites_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.sites_id_seq', 1, false);
+
+
+--
+-- Name: storage_devices_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.storage_devices_id_seq', 1, false);
+
+
+--
+-- Name: subnetworks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.subnetworks_id_seq', 1, false);
+
+
+--
+-- Name: tasks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.tasks_id_seq', 1, false);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.users_id_seq', 1, false);
+
+
+--
+-- Name: vlans_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.vlans_id_seq', 1, false);
+
+
+--
+-- Name: wans_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.wans_id_seq', 1, false);
+
+
+--
+-- Name: wifi_terminals_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.wifi_terminals_id_seq', 1, false);
+
+
+--
+-- Name: workstations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.workstations_id_seq', 1, false);
+
+
+--
+-- Name: zone_admins_id_seq; Type: SEQUENCE SET; Schema: public; Owner: jfc
+--
+
+SELECT pg_catalog.setval('public.zone_admins_id_seq', 1, false);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/resources/lang/en/cruds.php
+++ b/resources/lang/en/cruds.php
@@ -360,13 +360,15 @@ return [
             'security_level_helper' => 'ex. : maturity, security measures in place or defined at the contractual level, degree of confidence, approval',
         ],
         'filters' => [
-                'internes' => "Internal",
-                'externes' => "External",
-                'all'     => "All",
-        		'title'   => [
-			        'int/ext' => "Filter entities",
-		        ],
+            'internes' => "Internal",
+            'externes' => "External",
+            'all'     => "All",
+            'all_types' => "All types",
         ],
+		'title'   => [
+			'int/ext' => "Internal/External",
+			'type' => "Entity type",
+		],
         'title' => 'Entities',
         'title_singular' => 'Entity',
     ],

--- a/resources/lang/fr/cruds.php
+++ b/resources/lang/fr/cruds.php
@@ -343,6 +343,8 @@ return [
             'applications_resp_helper' => "Responsable de l'exploitation des applications",
             'contact_point' => 'Point de contact',
             'contact_point_helper' => '',
+            'entity_type' => "Type d'entité",
+            'entity_type_helper' => '',
             'is_external' => 'Externe à l\'organisme',
             'is_external_helper' => '',
             'databases_resp' => 'Bases de données',
@@ -363,9 +365,11 @@ return [
                 'internes' => "Internes",
                 'externes' => "Externes",
                 'all'     => "Toutes",
-		        'title'   => [
-		               'int/ext' => "Filtrer les entités",
-		        ]
+                'all_types' => "Tous les types",
+                'title'   => [
+                    'int/ext' => "Situation",
+                    'type' => "Type",
+                ]
         ],
         'title' => 'Entités',
         'title_singular' => 'Entité',

--- a/resources/views/admin/entities/create.blade.php
+++ b/resources/views/admin/entities/create.blade.php
@@ -51,16 +51,37 @@
             </div>
 
 	    <div class="form-group">
-            <div class="form-check form-switch">
-                <input name="is_external" id='is_external' type="checkbox" value="1" class="form-check-input" {{ old('is_external') ? 'checked="checked"' : '' }}>
-        		<label for="is_external">{{ trans('cruds.entity.fields.is_external') }}</label>
-            </div>
+		<div class="form-check form-switch">
+                    <input name="is_external" id='is_external' type="checkbox" value="1" class="form-check-input" {{ old('is_external') ? 'checked="checked"' : '' }}>
+        	    <label for="is_external">{{ trans('cruds.entity.fields.is_external') }}</label>
+		</div>
     		@if($errors->has('is_external'))
     		    <div class="invalid-feedback">
     			{{ $errors->first('is_external') }}
     		    </div>
     		@endif
     		<span class="help-block">{{ trans('cruds.entity.fields.is_external_helper') }}</span>
+	    </div>
+
+	    <div class="form-group">
+		<label for="entity_type">{{ trans('cruds.entity.fields.entity_type') }}</label>
+		<select class="form-control select2-free {{ $errors->has('entity_type') ? 'is-invalid' : '' }}"
+			name="entity_type" id="entity_type">
+		    <option></option>
+                    @foreach($entityTypes as $t)
+                        <option {{ old('entity_type') == $t ? 'selected' : '' }}>{{$t}}</option>
+                    @endforeach
+		    @if (!$entityTypes->contains(old('entity_type')))
+                        <option {{ old('entity_type') ? 'selected' : ''}}> {{ old('entity_type') }}</option>'
+		    @endif
+		</select>
+
+                @if($errors->has('entity_type'))
+                    <div class="invalid-feedback">
+                        {{ $errors->first('entity_type') }}
+                    </div>
+                @endif
+		<span class="help-block">{{ trans('cruds.entity.fields.entity_type_helper') }}</span>
 	    </div>
 	    
             <div class="form-group">

--- a/resources/views/admin/entities/edit.blade.php
+++ b/resources/views/admin/entities/edit.blade.php
@@ -52,16 +52,31 @@
             </div>
 	    
 	    <div class="form-group">
-            <div class="form-check form-switch">
-                <input name="is_external" id='is_external' type="checkbox" value="1" class="form-check-input" {{ old('is_external',$entity->is_external) ? 'checked="checked"' : '' }}>
-	           	<label for="is_external">{{ trans('cruds.entity.fields.is_external') }}</label>
-            </div>
+		<div class="form-check form-switch">
+                    <input name="is_external" id='is_external' type="checkbox" value="1" class="form-check-input" {{ old('is_external',$entity->is_external) ? 'checked="checked"' : '' }}>
+	            <label for="is_external">{{ trans('cruds.entity.fields.is_external') }}</label>
+		</div>
     		@if($errors->has('is_external'))
     		    <div class="invalid-feedback">
     			{{ $errors->first('is_external') }}
     		    </div>
     		@endif
-            <span class="help-block">{{ trans('cruds.entity.fields.is_external_helper') }}</span>
+		<span class="help-block">{{ trans('cruds.entity.fields.is_external_helper') }}</span>
+	    </div>
+
+	    
+	    <div class="form-group">
+		<label for="entity_type">{{ trans('cruds.entity.fields.entity_type') }}</label>
+		<select class="form-control select2-free {{ $errors->has('entity_type') ? 'is-invalid' : '' }}"
+			       name="entity_type" id="entity_type">
+		    @if (!$entityTypes->contains(old('entity_type')))
+                        <option> {{ old('entity_type') }}</option>'
+		    @endif
+                    @foreach($entityTypes as $t)
+                        <option {{ (old('entity_type') ? old('entity_type') : $entity->entity_type) == $t ? 'selected' : '' }}>{{$t}}</option>
+                    @endforeach
+		</select>
+		<span class="help-block">{{ trans('cruds.entity.fields.entity_type_helper') }}</span>
 	    </div>
 	    
             <div class="form-group">

--- a/resources/views/admin/entities/index.blade.php
+++ b/resources/views/admin/entities/index.blade.php
@@ -49,6 +49,7 @@
                     @foreach($entities as $key => $entity)
                         <tr data-entry-id="{{ $entity->id }}"
                             @if(($entity->description==null)||
+                                ($entity->is_external==null)||
                                 ($entity->contact_point==null)||
                                 ($entity->security_level==null)||
                                 ($entity->contact_point==null)||

--- a/resources/views/admin/entities/show.blade.php
+++ b/resources/views/admin/entities/show.blade.php
@@ -59,6 +59,14 @@
                     </tr>
                     <tr>
                         <th>
+                            {{ trans('cruds.entity.fields.entity_type') }}
+                        </th>
+                        <td>
+                            {!! $entity->entity_type !!}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
                             {{ trans('cruds.entity.fields.security_level') }}
                         </th>
                         <td>

--- a/resources/views/admin/reports/ecosystem.blade.php
+++ b/resources/views/admin/reports/ecosystem.blade.php
@@ -21,6 +21,12 @@
 			    <table class="table table-bordered table-striped">
 				<tr>
 				    <td>{{ trans('cruds.entity.filters.title.int/ext') }}
+				    </td>
+				    <td>{{ trans('cruds.entity.filters.title.type') }}
+				    </td>
+				</tr>
+				<tr>
+				    <td>
 					<select name="perimeter" onchange="this.form.submit()">
 					    @if (Session::get('perimeter')==null)
 						<option value="All" selected >trans('cruds.entity.filters.all')</option>
@@ -33,6 +39,15 @@
 						    >{{ $choice }}</option>
 					    @endforeach
 					    @endif
+					</select>
+				    </td>
+				    <td>
+					<select name="entity_type" onchange="this.form.submit()">
+						<option value="All" {{ Session::get('entity_type')== null ? "selected" : "" }} >{{ trans('cruds.entity.filters.all_types') }}</option>
+						@foreach ($entityTypes as $type)
+						    <option value="{{ $type }}" {{ Session::get('entity_type')==$type? "selected" : "" }}
+						    >{{ $type }}</option>
+						@endforeach
 					</select>
 				    </td>
 				</tr>
@@ -228,7 +243,7 @@
 <!-- https://unpkg.com/d3-graphviz@3.0.5/build/d3-graphviz.js -->
 <script src="/js/d3-graphviz.js"></script>
 
-<script>
+<script id="dot-input">
  let dotSrc = `
   digraph  {
   @can('entity_show')

--- a/tests/Browser/EcoSystemViewFiltersTest.php
+++ b/tests/Browser/EcoSystemViewFiltersTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+class EcoystemViewFiltersTest extends DuskTestCase
+{
+    public function testPerimeter() {
+        $admin = \App\User::find(1);
+        retry($times = 5,  function () use ($admin) {
+            $this->browse(function (Browser $browser) use ($admin) {
+                $browser->loginAs($admin);
+                $browser->visit(route('admin.report.view.ecosystem'));
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSee('Toutes');
+                $browser->assertSelected('perimeter', 'All');
+                /*
+                $digraph = $browser->element('#dot-input');
+                $this->assertEquals(1, substr_count($digraph,'digraph'),"toto".$digraph);
+                echo $digraph;
+                $browser->with('#dot-input', function ($elt) use ($digraph){
+                    $elt->assertSee('digraph',$digraph);
+                });
+                */
+                
+                
+                $browser->select('perimeter', 'Internes');
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSelected('perimeter', 'Internes');
+                $browser->assertSee('Internes');
+                
+                $browser->select('perimeter', 'Externes');
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSelected('perimeter', 'Externes');
+                $browser->assertSee('Externes');
+            });
+        });
+    }
+    
+    public function testEntityType() {
+        
+        $entity = \App\Entity::where('name','Acme corp.')->first();
+        $this->assertTrue($entity!=null);
+        $this->assertEquals('Producteur',$entity->entity_type);
+        
+        $entity = \App\Entity::where('name','MegaNet System')->first();
+        $this->assertEquals('Revendeur',$entity->entity_type);
+        
+        $entity = \App\Entity::where('name','Entité1')->first();
+        $this->assertEquals('Revendeur',$entity->entity_type);
+        
+        $entity = \App\Entity::where('name','Entité3')->first();
+        $this->assertEquals('Producteur',$entity->entity_type);
+        
+        $admin = \App\User::find(1);
+        retry($times = 5,  function () use ($admin) {
+            $this->browse(function (Browser $browser) use ($admin) {
+                $browser->loginAs($admin);
+                $browser->visit(route('admin.report.view.ecosystem'));
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSelected('perimeter', 'All');
+
+                $browser->with('#graph', function ($elt){
+                    $elt->assertSee('MegaNet System');
+                    $elt->assertSee('Acme');
+                    $elt->assertSee('Entité5');
+                });
+                $browser->visit('/admin/report/ecosystem?entity_type=Improbable');
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSelected('perimeter', 'All');
+                $browser->with('#graph', function ($elt){
+                    $elt->assertDontSee('Acme');
+                    $elt->assertDontSee('MegaNet System');
+                    $elt->assertDontSee('Entité5');
+                });
+                
+                
+                $browser->visit('/admin/report/ecosystem?entity_type=Producteur');
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSelected('perimeter', 'All');
+                $browser->with('#graph', function ($elt){
+                    $elt->assertSee('Acme');
+                    $elt->assertDontSee('MegaNet System');
+                    $elt->assertDontSee('Entité5');
+                });
+
+                $browser->visit('/admin/report/ecosystem?entity_type=Revendeur');
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSelected('perimeter', 'All');
+                
+                $browser->with('#graph', function ($elt){
+                    $elt->assertSee('MegaNet System');
+                    $elt->assertDontSee('Acme');
+                    $elt->assertDontSee('Entité5');
+                });
+                
+            });
+        });
+    }
+    public function testEntityFilterOnType() {
+        $admin = \App\User::find(1);
+        retry($times = 5,  function () use ($admin) {
+            $this->browse(function (Browser $browser) use ($admin) {
+                $browser->loginAs($admin);
+                $browser->visit(route('admin.report.view.ecosystem'));
+                $browser->assertRouteIs('admin.report.view.ecosystem');
+                $browser->assertSee('Mercator');
+                $browser->assertSelected('perimeter', 'All');
+                $browser->assertSee('Tous les types');
+                
+                $browser->assertSelected('entity_type', 'All');
+
+                
+                $allEntities = DB::table('entities');
+                $allTypes = $allEntities->groupBy('entity_type')->pluck('entity_type','entity_type');
+                foreach($allTypes as $entity_type){
+                    if ($entity_type ==null ) continue;
+                    
+                    $browser->select('entity_type', $entity_type);
+                    
+                    $browser->assertSee('Mercator');
+                    $browser->assertSelected('perimeter', 'All');
+                    $browser->with('#graph', function ($elt) use($entity_type){
+                        foreach (DB::table('entities')->whereNull('deleted_at')->get() as $entity){
+                            if ($entity->entity_type == $entity_type){
+                                $elt->assertSee($entity->name);
+                            } else{
+                                $elt->assertDontSee($entity->name);
+                            }
+                        }
+                    });
+                }
+                $browser->select('entity_type', 'All');
+                
+                $browser->assertSee('Mercator');
+                $browser->with('#graph', function ($elt){
+                    foreach (DB::table('entities')->whereNull('deleted_at')->get() as $entity){
+                        $elt->assertSee($entity->name);
+                    }
+                });
+            });
+        });
+    }
+}

--- a/tests/Browser/EntityTest.php
+++ b/tests/Browser/EntityTest.php
@@ -24,7 +24,7 @@ class EntityTest extends DuskTestCase
     public function testView()
     {
         $admin = \App\User::find(1);
-		$data = \DB::table('entities')->first();
+		$data = \DB::table('entities')->whereNull('deleted_at')->first();
 		if ($data!=null) 
         retry($times = 5,  function () use ($admin,$data) {
             $this->browse(function (Browser $browser) use ($admin,$data) {
@@ -40,7 +40,7 @@ class EntityTest extends DuskTestCase
     public function testEdit()
     {
         $admin = \App\User::find(1);
-		$data = \DB::table('entities')->first();
+		$data = \DB::table('entities')->whereNull('deleted_at')->first();
 		if ($data!=null) 
         retry($times = 5,  function () use ($admin,$data) {
             $this->browse(function (Browser $browser) use ($admin,$data) {


### PR DESCRIPTION
Entity types, types may be used to filter displayed elements on ecosystem view.

Postgres: example data in pg_mercator_data.sql, some mentions
of Postgres in INSTALL.md

Tests: Added dusk tests for filters in ecosystem view, modified Entities
test to account for soft-deleted elements.

.gitignore : ignore test artifacts (*.xlsx, *.log)