### PR TITLE
Fix the creation of duplicate application names with the API

### DIFF
--- a/app/Http/Requests/StoreApplicationRequest.php
+++ b/app/Http/Requests/StoreApplicationRequest.php
@@ -20,7 +20,9 @@ class StoreApplicationRequest extends FormRequest
         return [
             'name' => [
                 'min:3',
+                'max:32',
                 'required',
+                'unique:m_applications,name,NULL,id,deleted_at,NULL',
             ],
             'entities.*' => [
                 'integer',

--- a/app/Http/Requests/UpdateApplicationRequest.php
+++ b/app/Http/Requests/UpdateApplicationRequest.php
@@ -20,7 +20,9 @@ class UpdateApplicationRequest extends FormRequest
         return [
             'name' => [
                 'min:3',
+                'max:32',
                 'required',
+                'unique:m_applications,name,'.request()->route('application')->id.',id,deleted_at,NULL',
             ],
             'entities.*' => [
                 'integer',


### PR DESCRIPTION
Il était possible de créer plusieurs applications portant le même nom via l’API alors que cela n’était pas possible via l’application.