### PR TITLE
Fix subnetwork renaming migration

### DIFF
--- a/database/migrations/2021_05_19_161123_rename_subnetwork.php
+++ b/database/migrations/2021_05_19_161123_rename_subnetwork.php
@@ -21,7 +21,6 @@ class RenameSubnetwork extends Migration
         Schema::rename('network_subnetword', 'network_subnetwork');
 
         Schema::table('network_subnetwork', function (Blueprint $table) {
-            $table->renameIndex('subnetword_id_fk_1492377', 'subnetwork_id_fk_1492377');
             $table->renameColumn('subnetword_id', 'subnetwork_id');
         });
 
@@ -51,7 +50,6 @@ class RenameSubnetwork extends Migration
         Schema::rename('network_subnetwork', 'network_subnetword');
 
         Schema::table('network_subnetword', function (Blueprint $table) {
-            $table->renameIndex('subnetwork_id_fk_1492377', 'subnetword_id_fk_1492377');
             $table->renameColumn('subnetwork_id', 'subnetword_id');
         });
 


### PR DESCRIPTION
Le code tentait de renommer l’index après l’avoir supprimé (et ce avant d’en créer un autre avec le bon nom), d’où l’erreur :
Run php artisan migrate –seed
Migrating : 2021_05_19_161123_rename_subnetwork
Illuminate\Database\QueryException
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'index `subnetword_id_fk_1492377` to `subnetwork_id_fk_1492377`' at line 1 (SQL: alter table `network_subnetwork` rename index `subnetword_id_fk_1492377` to `subnetwork_id_fk_1492377`)