### PR TITLE
Update INSTALL.fr.md

### DIFF
--- a/INSTALL.fr.md
+++ b/INSTALL.fr.md
@@ -19,7 +19,7 @@ Installer Apache2, GIT, Graphviz et Composer
 
 Installer PHP et les librairies
 
-    sudo apt install php-zip php-curl php-mbstring php-dom php-ldap php-soap php-xdebug php-mysql php-gd
+    sudo apt install php-zip php-curl php-mbstring php-dom php-ldap php-soap php-xdebug php-mysql php-gd libapache2-mod-php
 
 ## Project
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Update the linux distribution
 
 Install PHP and some PHP libraries
 
-    sudo apt install php php-zip php-curl php-mbstring php-dom php-ldap php-soap php-xdebug php-mysql php-gd
+    sudo apt install php-zip php-curl php-mbstring php-dom php-ldap php-soap php-xdebug php-mysql php-gd libapache2-mod-php
 
 Install Apache2, GIT, Graphviz et Composer
 


### PR DESCRIPTION
Suite a une installation de Mercator manuelle sur une Ubuntu 22.04 toute neuve, il semble necessaire d'ajouter libapache2-mod-php pour que les pages PHP soit interprétées, sinon on voit le code source du point d'entrée Laravel en lieu et place. (Bizarre, je n'avais pas eu le souci avec ubuntu 20.04)