### PR TITLE
Fix Physical Link connected to Logical Routers in exploration view

### DIFF
--- a/app/Http/Controllers/Admin/ExplorerController.php
+++ b/app/Http/Controllers/Admin/ExplorerController.php
@@ -157,7 +157,7 @@ class ExplorerController extends Controller
             elseif ($link->network_switch_src_id!==null)
                 $src_id = 'LSWITCH_' . $link->network_switch_src_id;
             elseif ($link->router_src_id!==null)
-                $src_id = 'LROUTER' . $link->router_src_id;
+                $src_id = 'ROUTER_' . $link->router_src_id;
             else
                 continue;
 
@@ -184,7 +184,7 @@ class ExplorerController extends Controller
             elseif ($link->network_switch_dest_id!==null)
                 $dest_id = 'LSWITCH_' . $link->network_switch_dest_id;
             elseif ($link->router_dest_id!==null)
-                $dest_id = 'LROUTER' . $link->router_dest_id;
+                $dest_id = 'ROUTER_' . $link->router_dest_id;
             else
                 continue;
 


### PR DESCRIPTION
Hello Didier,
Juste un quickfix pour un petit bug repéré par notre cartographe réseau, où les "Liens physiques" connectés aux routeurs logiques n'apparaissaient pas dans la vue d'exploration 