### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,10 @@ RUN addgroup -S www && \
 # COPY nginx.conf /etc/nginx/http.d/mercator.conf
 # RUN chown -R mercator:www 
 
-RUN mkdir -p /etc/nginx/templates && cp docker/nginx.conf /etc/nginx/templates/mercator.conf
-RUN cp docker/supervisord.conf /etc/supervisord.conf 
+RUN cp docker/nginx.conf /etc/nginx/http.d/default.conf
+RUN cp docker/supervisord.conf /etc/supervisord.conf
+RUN chown -R mercator:www /etc/nginx/http.d/default.conf
+
 
 USER mercator:www
 
@@ -59,4 +61,4 @@ RUN set -ex ; \
 
 EXPOSE 8000
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]


### PR DESCRIPTION
by default not configuration nains is charge because is default.conf and path is false

and I have error docker Error: could not find config file  /etc/supervisor/conf.d/supervisord.conf
For help, use /usr/bin/supervisord -h

is correct because if indicate path to config load