### PR TITLE
Fix delete admin user

### DIFF
--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\AdminUser;
 use App\DomaineAd;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\MassDestroyAdminUSerRequest;
+use App\Http\Requests\MassDestroyAdminUserRequest;
 use App\Http\Requests\StoreAdminUserRequest;
 use App\Http\Requests\UpdateAdminUserRequest;
 use Gate;
@@ -43,7 +43,7 @@ class AdminUserController extends Controller
 
     public function edit(AdminUser $adminUser)
     {
-        abort_if(Gate::denies('activity_edit'), Response::HTTP_FORBIDDEN, '403 Forbidden');
+        abort_if(Gate::denies('admin_user_edit'), Response::HTTP_FORBIDDEN, '403 Forbidden');
 
         $type_list = AdminUser::select('type')->where('type', '<>', null)->distinct()->orderBy('type')->pluck('type');
         $domains = DomaineAd::all()->sortBy('name')->pluck('name', 'id');
@@ -65,18 +65,18 @@ class AdminUserController extends Controller
 
     public function show(AdminUser $adminUser)
     {
-        abort_if(Gate::denies('activity_show'), Response::HTTP_FORBIDDEN, '403 Forbidden');
+        abort_if(Gate::denies('admin_user_show'), Response::HTTP_FORBIDDEN, '403 Forbidden');
 
         return view('admin.adminUser.show', compact('adminUser'));
     }
 
-    public function destroy(AdminUser $user)
+    public function destroy(AdminUser $adminUser)
     {
         abort_if(Gate::denies('admin_user_delete'), Response::HTTP_FORBIDDEN, '403 Forbidden');
 
-        $user->delete();
+        $adminUser->delete();
 
-        return redirect()->route('admin.adminUser.index');
+        return redirect()->route('admin.admin-users.index');
     }
 
     public function massDestroy(MassDestroyAdminUserRequest $request)

--- a/app/Http/Requests/MassDestroyAdminUserRequest.php
+++ b/app/Http/Requests/MassDestroyAdminUserRequest.php
@@ -19,7 +19,7 @@ class MassDestroyAdminUserRequest extends FormRequest
     {
         return [
             'ids' => 'required|array',
-            'ids.*' => 'exists:activities,id',
+            'ids.*' => 'exists:admin_users,id',
         ];
     }
 }

--- a/resources/views/admin/adminUser/index.blade.php
+++ b/resources/views/admin/adminUser/index.blade.php
@@ -16,7 +16,7 @@
 
     <div class="card-body">
         <div class="table-responsive">
-            <table class=" table table-bordered table-striped table-hover datatable datatable-Actor">
+            <table class=" table table-bordered table-striped table-hover datatable datatable-AdminUser">
                 <thead>
                     <tr>
                         <th width="10">
@@ -107,11 +107,11 @@
 <script>
     $(function () {
   let dtButtons = $.extend(true, [], $.fn.dataTable.defaults.buttons)
-@can('actor_delete')
+@can('admin_user_delete')
   let deleteButtonTrans = '{{ trans('global.datatables.delete') }}'
   let deleteButton = {
     text: deleteButtonTrans,
-    url: "{{ route('admin.actors.massDestroy') }}",
+    url: "{{ route('admin.admin-users.massDestroy') }}",
     className: 'btn-danger',
     action: function (e, dt, node, config) {
       var ids = $.map(dt.rows({ selected: true }).nodes(), function (entry) {
@@ -141,7 +141,7 @@
     order: [[ 1, 'asc' ]],
     pageLength: 100, stateSave: true,
   });
-  let table = $('.datatable-Actor:not(.ajaxTable)').DataTable({ buttons: dtButtons })
+  let table = $('.datatable-AdminUser:not(.ajaxTable)').DataTable({ buttons: dtButtons })
   $('a[data-toggle="tab"]').on('shown.bs.tab', function(e){
       $($.fn.dataTable.tables(true)).DataTable()
           .columns.adjust();


### PR DESCRIPTION
Il y avait des problèmes lors de la suppression des données dans la vue administrateurs. J'ai apporté quelques modifications pour corriger ce problème.

**Modifications**

- Correction des autorisations dans les méthodes du contrôleur AdminUserController.
- Correction des règles de validation dans MassDestroyAdminUserRequest.
- Mise à jour de la vue index.blade.php pour la gestion correcte des suppressions.