### PR TITLE
Modification du port d'écoute nginx 

### DIFF
--- a/docker-compose/PV/nginx/nginx.conf
+++ b/docker-compose/PV/nginx/nginx.conf
@@ -10,7 +10,7 @@ http {
     ## redirect http -> https
     #################################
     server {
-        listen 80 default_server;
+        listen 8080 default_server;
         server_name _;
 
         location / {

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ../app/Http/Kernel.php:/var/www/mercator/app/Http/Kernel.php
       - ../app/Http/Middleware/ForceXForwardedProto.php:/var/www/mercator/app/Http/Middleware/ForceXForwardedProto.php
     expose:
-      - 80
+      - 8080
     environment:
       ##########################################
       # CONFIG set to your company's domain name

--- a/docker/assets/apache/8000-mercator.conf
+++ b/docker/assets/apache/8000-mercator.conf
@@ -2,7 +2,7 @@
 # SRC : https://github.com/dbarzin/mercator/
 
 # redirect : 80 -> 443
-<VirtualHost *:80>
+<VirtualHost *:8080>
         ServerName mercator.mydomain.com
         ServerAdmin admin@mydomain.com
 

--- a/docker/assets/nginx/8000-mercator.conf
+++ b/docker/assets/nginx/8000-mercator.conf
@@ -3,7 +3,7 @@
 
 # redirect : 80 -> 443
 server {
-  listen 80;
+  listen 8080;
   server_name   mercator.mydomain.com;
   rewrite       ^ https://$server_name$request_uri? permanent;
   access_log /var/log/nginx/mercator-http.log;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,6 @@
 server {
-    listen 80;
-    listen [::]:80;
+    listen 8080;
+    listen [::]:8080;
     server_name "127.0.0.1 localhost";
     root /var/www/mercator/public;
     #compatibility in https behind reverse proxy example: traefik


### PR DESCRIPTION
Modification du port d'écoute de Nginx de 80 à 8080 pour permettre le démarrage du pod Mercator sur Kubernetes.