### PR TITLE
Ajout de fonctionnalités Keycloak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,4 +68,6 @@ KEYCLOAK = disable # Make it enable
 #KEYCLOAK_REDIRECT_URI=<Mercator IP Address>/login/keycloak/callback
 #KEYCLOAK_BASE_URL=<KeyCloak IP Address>
 #KEYCLOAK_REALM=   # RealM Name
+#KEYCLOAK_AUTO_PROVISIONNING=false # uncomment to disable the automatic creation of users
+#KEYCLOAK_BTN_LABEL="Connexion SSO" # set the Keycloak login button label (defaults to 'Keycloak')
 ##########################################################################

--- a/INSTALL.fr.md
+++ b/INSTALL.fr.md
@@ -230,6 +230,8 @@ KEYCLOAK_CLIENT_SECRET=  # Client Secret
 KEYCLOAK_REDIRECT_URI=<Mercator IP Address>/login/keycloak/callback
 KEYCLOAK_BASE_URL=<KeyCloak IP Address>
 KEYCLOAK_REALM=   # RealM Name
+KEYCLOAK_AUTO_PROVISIONNING= # active/désactive la création automatique d'utilisateurs (valeurs possibles : true/false. 'true' par défaut)
+KEYCLOAK_BTN_LABEL= # défini le libellé du bouton de connexion Keycloak ('Keycloak' par défaut)
 ```
 
 Après avoir défini KEYCLOAK sur enable, un bouton apparaîtra sur la page de connexion, permettant aux utilisateurs de se connecter via Keycloak.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -231,6 +231,8 @@ KEYCLOAK_CLIENT_SECRET=  # Client Secret
 KEYCLOAK_REDIRECT_URI=<Mercator IP Address>/login/keycloak/callback
 KEYCLOAK_BASE_URL=<KeyCloak IP Address>
 KEYCLOAK_REALM=   # RealM Name
+KEYCLOAK_AUTO_PROVISIONNING= # enable/disable the automatic creation of users (possibles values: true/false. defaults to 'true')
+KEYCLOAK_BTN_LABEL= # set the Keycloak login button label (defaults to 'Keycloak')
 ```
 
 Once you make the KEYCLOAK parametre in 'enable' you would see a bouton in Login page that redirect to keycloak server

--- a/app/Http/Controllers/Auth/SsoController.php
+++ b/app/Http/Controllers/Auth/SsoController.php
@@ -25,12 +25,20 @@ class SsoController extends Controller
         }
 
         // Récupérer les rôles de Keycloak
-        $roles = $keycloakUser->user['realm_access']['roles'];
+        try {
+            $roles = $keycloakUser->user['realm_access']['roles'];
+        } catch (\Exception $e) {
+            $roles = array();
+        }
 
         // Trouver ou créer l'utilisateur dans la base de données locale
         $existingUser = User::where('email', $keycloakUser->email)->first();
 
         if (! $existingUser) {
+            if (! env('KEYCLOAK_AUTO_PROVISIONNING')) {
+                return redirect()->route('login')->with('message', 'User "' . $keycloakUser->email . '" is not a valid Mercator user.');
+            }
+
             $existingUser = new User();
             $existingUser->name = $keycloakUser->name; // Supposons que Keycloak fournit le nom de l'utilisateur
             $existingUser->email = $keycloakUser->email;

--- a/app/Http/Controllers/Auth/SsoController.php
+++ b/app/Http/Controllers/Auth/SsoController.php
@@ -35,7 +35,7 @@ class SsoController extends Controller
         $existingUser = User::where('email', $keycloakUser->email)->first();
 
         if (! $existingUser) {
-            if (! env('KEYCLOAK_AUTO_PROVISIONNING')) {
+            if (! env('KEYCLOAK_AUTO_PROVISIONNING', true)) {
                 return redirect()->route('login')->with('message', 'User "' . $keycloakUser->email . '" is not a valid Mercator user.');
             }
 

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,6 @@ return [
         'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
         'redirect' => env('KEYCLOAK_REDIRECT_URI'),
         'base_url' => env('KEYCLOAK_BASE_URL'),  
-        'realms' => env('KEYCLOAK_REALM')         
+        'realms' => env('KEYCLOAK_REALM')
       ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,6 @@ return [
         'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
         'redirect' => env('KEYCLOAK_REDIRECT_URI'),
         'base_url' => env('KEYCLOAK_BASE_URL'),  
-        'realms' => env('KEYCLOAK_REALM')
+        'realms' => env('KEYCLOAK_REALM')   
       ],
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -103,7 +103,7 @@
                 @if(env('KEYCLOAK') === 'enable')
                     <!-- Ajout du bouton pour se connecter via Keycloak -->
                     <div class="text-right mt-3">
-                        <a href="{{ route('login.keycloak') }}" class="btn btn-secondary">Keycloak</a>
+                        <a href="{{ route('login.keycloak') }}" class="btn btn-secondary">{{ (env('KEYCLOAK_BTN_LABEL') === null) ? "Keycloak" : env('KEYCLOAK_BTN_LABEL') }}</a>
                     </div>
                 @endif
 


### PR DESCRIPTION
Ajout de fonctionnalités (rétro-compatibles aux versions précédentes) sur la connexion Keycloak : 
- Paramètre KEYCLOAK_AUTO_PROVISIONNING permettant de désactiver la création automatique de comptes Mercator lors d'une authentification Keycloak (si désactivé, le compte doit avoir été créé au préalable dans Mercator)
- Paramètre KEYCLOAK_BTN_LABEL permettant de personnaliser si nécessaire le label du bouton de connexion Keycloak
- Possibilité de ne pas retourner les rôles dans l'id token de Keycloak (avant modif, l'app retournait une erreur 500 s'ils n'étaient pas présents)

Le tout permet de brancher un client Keycloak 'simple' en gardant la gestion des comptes utilisateurs et rôles dans Mercator directement.

A noter que pour utiliser l'authentification Keycloak dans Mercator j'ai du jouer la commande suivante **post-déploiement** :
`composer require socialiteproviders/keycloak`
Mes tentatives d'intégration de cette commande pré-déploiement ont généré des modifications dans _composer.json_ et _composer.lock_ que je ne maitrisais pas et ne préférais pas pousser...