### PR TITLE
Add documentation about php-fpm use in INSTALL* files

### DIFF
--- a/INSTALL.RedHat.fr.md
+++ b/INSTALL.RedHat.fr.md
@@ -307,6 +307,58 @@ Pour forcer le redirection en HTTPS, il faut mettre ce paramètre dans le fichie
 
     APP_ENV=production
 
+### Variante PHP-FPM
+
+Installer le paquet php-fpm :
+
+```bash
+sudo dnf install php-fpm
+```
+
+Le fichier de configuration du virtual host devient alors
+
+```xml
+<VirtualHost *:80>
+    ServerName mercator.local
+    ServerAdmin admin@example.com
+    DocumentRoot /var/www/mercator/public
+    <Directory /var/www/mercator>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog /var/log/httpd/mercator_error.log
+    CustomLog /var/log/httpd/mercator_access.log combined
+</VirtualHost>
+```
+
+Et pour du HTTPS
+
+```xml
+<VirtualHost *:443>
+    ServerName carto.XXXXXXXX
+    ServerAdmin
+    DocumentRoot /var/www/mercator/public
+    SSLEngine on
+    SSLProtocol all -SSLv2 -SSLv3
+    SSLCipherSuite HIGH:3DES:!aNULL:!MD5:!SEED:!IDEA
+    SSLCertificateFile /etc/httpd/certs/certs/carto.XXXXX.crt
+    SSLCertificateKeyFile /etc/httpd/certs/private/private.key
+    SSLCertificateChainFile /etc/httpd/certs/certs/XXXXXCA.crt
+    <Directory /var/www/mercator/public>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog /var/log/httpd/mercator_error.log
+    CustomLog /var/log/httpd/mercator_access.log combined
+</VirtualHost>
+```
+
 ## Problèmes
 
 ### Restaurer le mot de passe administrateur

--- a/INSTALL.RedHat.md
+++ b/INSTALL.RedHat.md
@@ -305,6 +305,58 @@ add this line to the crontab
 
       APP_ENV=production
 
+### PHP-FPM variation
+
+Install php-fpm :
+
+```bash
+sudo dnf install php-fpm
+```
+
+Configuration file is now
+
+```xml
+<VirtualHost *:80>
+    ServerName mercator.local
+    ServerAdmin admin@example.com
+    DocumentRoot /var/www/mercator/public
+    <Directory /var/www/mercator>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog /var/log/httpd/mercator_error.log
+    CustomLog /var/log/httpd/mercator_access.log combined
+</VirtualHost>
+```
+
+With HTTPS
+
+```xml
+<VirtualHost *:443>
+    ServerName carto.XXXXXXXX
+    ServerAdmin
+    DocumentRoot /var/www/mercator/public
+    SSLEngine on
+    SSLProtocol all -SSLv2 -SSLv3
+    SSLCipherSuite HIGH:3DES:!aNULL:!MD5:!SEED:!IDEA
+    SSLCertificateFile /etc/httpd/certs/certs/carto.XXXXX.crt
+    SSLCertificateKeyFile /etc/httpd/certs/private/private.key
+    SSLCertificateChainFile /etc/httpd/certs/certs/XXXXXCA.crt
+    <Directory /var/www/mercator/public>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog /var/log/httpd/mercator_error.log
+    CustomLog /var/log/httpd/mercator_access.log combined
+</VirtualHost>
+```
+
  ## Problems
 
  ### Restore administrator password

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -317,6 +317,72 @@ To force HTTPS redirection you have to set this parameter in .env
 
     APP_ENV=production
 
+### Variante PHP-FPM
+
+Install php-fpm :
+
+```bash
+sudo apt install php-fpm
+```
+
+Disable Apache PHP and MPM prefork modules
+
+```bash
+sudo a2dismod mpm_prefork phpx.y
+```
+
+Activate Apache FastCGI and MPM event modules
+
+```bash
+sudo a2enmod proxy_fcgi mpm_event
+```
+
+Configure MPM event module with the file `/etc/apache2/mods-enabled/mpm_event.conf` according to the documentation <https://httpd.apache.org/docs/current/mod/event.html>
+
+Configuration file is now
+
+```xml
+<VirtualHost *:80>
+    ServerName mercator.local
+    ServerAdmin admin@example.com
+    DocumentRoot /var/www/mercator/public
+    <Directory /var/www/mercator>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+```
+
+With HTTPS
+
+```xml
+<VirtualHost *:443>
+    ServerName carto.XXXXXXXX
+    ServerAdmin
+    DocumentRoot /var/www/mercator/public
+    SSLEngine on
+    SSLProtocol all -SSLv2 -SSLv3
+    SSLCipherSuite HIGH:3DES:!aNULL:!MD5:!SEED:!IDEA
+    SSLCertificateFile /etc/apache2/certs/certs/carto.XXXXX.crt
+    SSLCertificateKeyFile /etc/apache2/certs/private/private.key
+    SSLCertificateChainFile /etc/apache2/certs/certs/XXXXXCA.crt
+    <Directory /var/www/mercator/public>
+        AllowOverride All
+    </Directory>
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+        SetHandler "proxy:unix:/run/php/php-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+    ErrorLog ${APACHE_LOG_DIR}/mercator_error.log
+    CustomLog ${APACHE_LOG_DIR}/mercator_access.log combined
+</VirtualHost>
+```
+
 ## Problems
 
 ### Restore the administrator password


### PR DESCRIPTION
We wanted to use mercator with php-fpm so we write the doc in our intern documentation.
Now we contribute back.