### PR TITLE
fix: update chart release target branch

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -3,9 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
-      - ci
-
+      - master
 jobs:
   release:
     name: Release Helm Charts
@@ -31,5 +29,4 @@ jobs:
           charts_dir: _helm_chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: true
           


### PR DESCRIPTION
In [PR #1328](https://github.com/dbarzin/mercator/pull/1328) the helm release GH action was triggered on the wrong branch.
This sets the target branch to `master` in `.github/workflows/chart-release.yaml`

