### PR TITLE
Update chart-release.yaml

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           charts_dir: _helm_chart
           skip_existing: true
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           


### PR DESCRIPTION
Permet de ne pas marquer la release de la chart helm comme release latest de mercator