### PR TITLE
feat: Add support for logical servers association in PhysicalServer API

### DIFF
--- a/app/Http/Controllers/API/PhysicalServerController.php
+++ b/app/Http/Controllers/API/PhysicalServerController.php
@@ -53,7 +53,10 @@ class PhysicalServerController extends Controller
 
         // Update all fields except logicalServers (handled separately)
         $physicalServer->update($request->except('logicalServers'));
-        $physicalServer->applications()->sync($request->input('applications', []));
+        
+        if ($request->has('applications')) {
+            $physicalServer->applications()->sync($request->input('applications', []));
+        }
         
         // Handle logical servers association via API
         if ($request->has('logicalServers')) {


### PR DESCRIPTION
## Purpose

Add support for automatic logical servers association when creating or updating physical servers via API.

This enables automated inventory systems to establish Many-to-Many relationships between physical servers and their associated logical servers through the API endpoint.

## Changes

### Modified file: `app/Http/Controllers/API/PhysicalServerController.php`

#### In `store()` method:
- Added support for `logicalServers` field in request payload
- Automatically sync logical servers when creating a physical server

#### In `update()` method:
- Modified to exclude `logicalServers` from normal field updates (handled separately)
- Added logical servers synchronization with logging
- Maintains existing behavior when `logicalServers` is not provided

## Features

- **Backward compatible**: Existing functionality unchanged
- **Optional**: Only activates when `logicalServers` field is provided
- **Secure**: Uses Laravel's built-in `sync()` method for Many-to-Many relations
- **Logge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - API now supports linking logical servers to a physical server during create and update. Provide logical server IDs in the request to automatically sync associations.
  - Existing application associations remain supported alongside the new logical server linking.
  - Response behavior is unchanged aside from processing logical server associations when included in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->