### PR TITLE
increase information name size

### DIFF
--- a/app/Http/Requests/StoreInformationRequest.php
+++ b/app/Http/Requests/StoreInformationRequest.php
@@ -21,7 +21,7 @@ class StoreInformationRequest extends FormRequest
         return [
             'name' => [
                 'min:3',
-                'max:32',
+                'max:64',
                 'required',
                 Rule::unique('information')->whereNull('deleted_at'),
             ],

--- a/app/Http/Requests/UpdateInformationRequest.php
+++ b/app/Http/Requests/UpdateInformationRequest.php
@@ -21,7 +21,7 @@ class UpdateInformationRequest extends FormRequest
         return [
             'name' => [
                 'min:3',
-                'max:32',
+                'max:64',
                 'required',
                 Rule::unique('information')
                     ->ignore($this->route('information')->id ?? $this->id)

--- a/resources/views/admin/information/create.blade.php
+++ b/resources/views/admin/information/create.blade.php
@@ -10,7 +10,7 @@
         <div class="card-body">
             <div class="form-group">
                 <label class="required" for="name">{{ trans('cruds.information.fields.name') }}</label>
-                <input class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" type="text" name="name" id="name" value="{{ old('name', '') }}" required maxlength="32" autofocus/>
+                <input class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" type="text" name="name" id="name" value="{{ old('name', '') }}" required maxlength="64" autofocus/>
                 @if($errors->has('name'))
                     <div class="invalid-feedback">
                         {{ $errors->first('name') }}

--- a/resources/views/admin/information/edit.blade.php
+++ b/resources/views/admin/information/edit.blade.php
@@ -12,7 +12,7 @@
         <div class="card-body">
             <div class="form-group">
                 <label class="required" for="name">{{ trans('cruds.information.fields.name') }}</label>
-                <input class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" type="text" name="name" id="name" value="{{ old('name', $information->name) }}" required maxlength="32" autofocus/>
+                <input class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" type="text" name="name" id="name" value="{{ old('name', $information->name) }}" required maxlength="64" autofocus/>
                 @if($errors->has('name'))
                     <div class="invalid-feedback">
                         {{ $errors->first('name') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased the allowed length for the “name” field from 32 to 64 characters across create and edit flows in the admin interface.
  - Updated client-side input limits and server-side validation to consistently accept names up to 64 characters.
  - Ensures smoother entry of longer names without changing other form behaviors or validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->