### PR TITLE
Fix: incorrect variable in workstation model dropdown

### DIFF
--- a/resources/views/admin/workstations/create.blade.php
+++ b/resources/views/admin/workstations/create.blade.php
@@ -114,7 +114,7 @@
                         <option> {{ old('model') }}</option>'
                     @endif
                     @foreach($model_list as $model)
-                        <option {{ old('model') == $manufacturer ? 'selected' : '' }}>{{$model}}</option>
+                        <option {{ old('model') == $model ? 'selected' : '' }}>{{$model}}</option>
                     @endforeach
                 </select>
                 @if($errors->has('model'))


### PR DESCRIPTION
## Description
This PR fixes a bug causing a 500 error when accessing the workstation creation form.

## Problem
The model dropdown was using the wrong variable in the comparison. Line 117 was comparing `old('model')` with `$manufacturer` instead of `$model`, causing an undefined variable error when rendering the form.

## Solution
Changed line 117 from:
```blade
<option {{ old('model') == $manufacturer ? 'selected' : '' }}>{{$model}}</option>
to:
<option {{ old('model') == $model ? 'selected' : '' }}>{{$model}}</option>