### PR TITLE
Fix INSTALL* files location after https://github.com/dbarzin/mercator…

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -66,8 +66,8 @@ Reconnu pour sa qualité et sa pertinence opérationnelle, Mercator s’impose a
 ### 🔧 Installation Manuelle
 
 Pour des instructions détaillées, veuillez vous référer aux guides d'installation :
-- [Installation sur Ubuntu](https://github.com/dbarzin/mercator/blob/master/INSTALL.md)
-- [Installation sur RedHat](https://github.com/dbarzin/mercator/blob/master/INSTALL.RedHat.md)
+- [Installation sur Ubuntu](https://github.com/dbarzin/mercator/blob/master/guides/INSTALL_VM.fr.md)
+- [Installation sur RedHat](https://github.com/dbarzin/mercator/blob/master/guides/INSTALL.RedHat.fr.md)
 
 ### 🐳 Installation via Docker
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ mapping and governance.
 
 For detailed instructions, please refer to the installation guides:
 
-- [Installation on Ubuntu](https://github.com/dbarzin/mercator/blob/master/INSTALL.md)
-- [Installation on RedHat](https://github.com/dbarzin/mercator/blob/master/INSTALL.RedHat.md)
+- [Installation on Ubuntu](https://github.com/dbarzin/mercator/blob/master/guides/INSTALL_VM.md)
+- [Installation on RedHat](https://github.com/dbarzin/mercator/blob/master/guides/INSTALL.RedHat.md)
 
 ### 🐳 Docker Installation
 


### PR DESCRIPTION
…/commit/d1737137acce8163443badef2f84149853e9c5a8

These files were moved / renamed in https://github.com/dbarzin/mercator/commit/d1737137acce8163443badef2f84149853e9c5a8 but README*.md were not updated to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance links in README files to reflect reorganized documentation structure. Ubuntu and RedHat installation guide references now point to the guides directory in both English and French versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->