### PR TITLE
Set group permissions for Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ RUN composer install --no-dev --no-interaction --prefer-dist --optimize-autoload
 # Copy application source (après composer pour meilleur cache)
 COPY --chown=mercator:www . .
 
+# For Openshift environment
+RUN chmod -R g=u /var/www/mercator
+
 # Copy version file et environment file
 COPY --chown=mercator:www version.txt ./version.txt
 RUN cp .env.sqlite .env


### PR DESCRIPTION
Est-il possible d'ajouter cette ligne, ça permet de fixer des permissions pour utiliser mercator sur un cluster Openshift.
Merci ! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration to enhance file access settings in deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->