### PR TITLE
Update links to subnetwork routes in logicalFlows view

### DIFF
--- a/resources/views/admin/logicalFlows/index.blade.php
+++ b/resources/views/admin/logicalFlows/index.blade.php
@@ -148,7 +148,7 @@
                                     <a href="{{ route('admin.logical-servers.show',$logicalFlow->logicalServerDest->id) }}">
                                         {{ $logicalFlow->logicalServerDest->name }}
                                     </a>)
-                                @elseif` ($logicalFlow->peripheralDest!==null)
+                                @elseif ($logicalFlow->peripheralDest!==null)
                                     {{ $logicalFlow->peripheralDest->address_ip }}
                                     (<a href="{{ route('admin.peripherals.show',$logicalFlow->peripheralDest->id) }}">
                                         {{ $logicalFlow->peripheralDest->name }}


### PR DESCRIPTION
should resolve #1874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed links that previously navigated to the wrong resource so subnet detail links now go to the correct subnetwork pages.
  * Corrected destination links so peripheral addresses route to the appropriate resource and resolved a template rendering issue that could break page display.
  * Removed an outdated destination branch so peripheral destinations are used consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->