### PR TITLE
Mise à jour des fichiers docs API et modèle (FR/EN)

### DIFF
--- a/docs/api.fr.md
+++ b/docs/api.fr.md
@@ -72,6 +72,7 @@ __Vue de l'infrastructure logique__
 - /api/clusters
 - /api/logical-servers
 - /api/logical-flows
+- /api/containers
 - /api/certificates
 - /api/vlans
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,7 @@ __Logical infrastructure view__
 - /api/clusters
 - /api/logical-servers
 - /api/logical-flows
+- /api/containers
 - /api/certificates
 - /api/vlans
 

--- a/docs/model.fr.md
+++ b/docs/model.fr.md
@@ -160,6 +160,8 @@ Dans l'application, un document peut être rattaché à une relation depuis un o
 
 Les valeurs financières d'un contrat peuvent être indiquées dans des champs dédiés.  
 
+---
+
 ### Vue métier du système d’information
 
 La vue métier du système d’information décrit l’ensemble des processus métiers de l’organisme avec les acteurs qui y
@@ -222,6 +224,11 @@ Table *processes* :
 | security_need_t    | int          | Traçabilité                         |
 | security_need_auth | int          | Authenticité                        |
 | macroprocess_id    | int unsigned | Référence vers le macro-processus   |
+| activities         | List int [,] | Liste d'id des activitées liées     |
+| entities           | List int [,] | Liste d'id des entitées liées       |
+| informations       | List int [,] | Liste d'id des informations liées   |
+| applications       | List int [,] | Liste d'id des applications liées   |
+| operations         | List int [,] | Liste d'id des operations liées     |
 | created_at         | timestamp    | Date de création                    |
 | updated_at         | timestamp    | Date de mise à jour                 |
 | deleted_at         | timestamp    | Date de suppression                 |
@@ -284,7 +291,7 @@ Une application peut être rattachée à une activité depuis ces deux objets.
 
 Dans l'application, les champs "Type d'impact" et "Gravité" sont gérés dans une table à part.
 
-#### Impacts
+##### Impacts
 
 Les impacts sont les conséquences de la survenue d'un risque lors d'une activité.  
 Les impacts ne sont accessibles qu'à travers les objets activités.  
@@ -314,7 +321,10 @@ Table *operations* :
 | id          | int unsigned | auto_increment                                           |
 | name        | varchar(255) | Nom de l'opération                                       |
 | description | longtext     | Description de l'opération                               |
-| process_id  | int unsigned | Référence vers le processus dont fait partie l'opération | 
+| process_id  | int unsigned | Référence vers le processus dont fait partie l'opération |
+| actors      | List int [,] | Liste d'id des acteurs liés                              |
+| tasks       | List int [,] | Liste d'id des taches liées                              |
+| activities  | List int [,] | Liste d'id des activitées liées                          |
 | created_at  | timestamp    | Date de création                                         |
 | updated_at  | timestamp    | Date de mise à jour                                      |
 | deleted_at  | timestamp    | Date de suppression                                      |
@@ -352,16 +362,17 @@ décisions dans le cadre des processus. Ce rôle peut être porté par une perso
 
 Table *actors* :
 
-| Champ      | Type         | Description         |
-|:-----------|:-------------|:--------------------|
-| id         | int unsigned | auto_increment      |
-| name       | varchar(255) | Nom de l'acteur     |
-| nature     | varchar(255) | Nature de l'acteur  |
-| type       | varchar(255) | Type d'acteur       |
-| contact    | varchar(255) | Contact de l'acteur |
-| created_at | timestamp    | Date de création    |
-| updated_at | timestamp    | Date de mise à jour |
-| deleted_at | timestamp    | Date de suppression |
+| Champ      | Type         | Description                       |
+|:-----------|:-------------|:----------------------------------|
+| id         | int unsigned | auto_increment                    |
+| name       | varchar(255) | Nom de l'acteur                   |
+| nature     | varchar(255) | Nature de l'acteur                |
+| type       | varchar(255) | Type d'acteur                     |
+| contact    | varchar(255) | Contact de l'acteur               |
+| operations | List int [,] | Liste d'id des operations liées   |
+| created_at | timestamp    | Date de création                  |
+| updated_at | timestamp    | Date de mise à jour               |
+| deleted_at | timestamp    | Date de suppression               |
 
 L'export du modèle de données référence les opérations rattachées à un acteur.  
 
@@ -402,6 +413,8 @@ Il s'active depuis le menu Configuration > Paramètres.
 L'export du modèle de données référence les bases de données et processus rattachés à une information.  
 Dans l'application, une base de donnée peut être rattachée à une information depuis l'objet base de données.  
 Un processus peut être rattachée à une information depuis ces deux objets. 
+
+---
 
 ### La vue des applications
 
@@ -452,7 +465,6 @@ Table *m_applications* :
 | description          | longtext     | Description de l'application                    |
 | icon_id              | int unsigned | Référence vers une image spécifique             |
 | responsible          | varchar(255) | Responsable de l'application                    | 
-| entity_resp_id       | int unsigned | Entité responsable de l'exploitation            |
 | functional_referent  | varchar(255) | Référent fonctionnel / métier de l'application  |
 | editor               | varchar(255) | Editeur de l'application                        |
 | users                | varchar(255) | Nombre d'utilisateurs et type                   |
@@ -461,6 +473,7 @@ Table *m_applications* :
 | external             | varchar(255) | Externe                                         |
 | install_date         | datetime     | Date d'installation de l'application            |
 | update_date          | datetime     | Date de mise à jour de l'application            |
+| next_update          | date         | Date de prochaine mise à jour                   |
 | documentation        | varchar(255) | Lien vers la documentation                      |
 | security_need_c      | int          | Confidentialité                                 |
 | security_need_i      | int          | Intégrité                                       |
@@ -473,7 +486,12 @@ Table *m_applications* :
 | product              | varchar(255) | Produit d'un éditeur pour recherche CPE         |
 | version              | varchar(255) | Version d'un produit pour recherche CPE         |
 | patching_frequency   | int          | Fréquence des mises à jour en part. de sécurité |
-| next_update          | date         | Date de prochaine mise à jour                   |
+| entities             | List int [,] | Liste d'id de(s) entitée(s) liée(s)             |
+| processes            | List int [,] | Liste d'id de(s) proces(ses) lié(s)             |
+| services             | List int [,] | Liste d'id de(s) service(s) lié(s)              |
+| databases            | List int [,] | Liste d'id de(s) database(s) liée(s)            |
+| logical_servers      | List int [,] | Liste d'id de(s) serveur(s) logique(s) servant(s) cette application  |
+| activities           | List int [,] | Liste d'id de(s) activitée(s) associée(s)       |
 | created_at           | timestamp    | Date de création                                |
 | updated_at           | timestamp    | Date de mise à jour                             |
 | deleted_at           | timestamp    | Date de suppression                             |
@@ -524,7 +542,7 @@ Ce bouton est présent dans la vue du RGDP et visible dans la liste des objets M
 Dans l'application, un conteneur peut être rattaché à une application depuis ces deux objets.  
 Dans l'application, le champ *évènements majeurs* est géré dans une table à part.
 
-#### Evènements majeurs
+##### Evènements majeurs
 
 Les évènements majeurs sont les principaux évènements subis par une application au cours de son exploitation.  
 Les évènements majeurs ne sont accessibles qu'à travers les objets applications.  
@@ -551,15 +569,17 @@ Un service applicatif peut, par exemple, être un service dans le nuage (Cloud).
 
 Table *application_services* :
 
-| Champ       | Type         | Description                       |
-|:------------|:-------------|:----------------------------------|
-| id          | int unsigned | auto_increment                    |
-| name        | varchar(255) | Nom du service applicatif         |
-| description | longtext     | Description du service applicatif |
-| exposition  | varchar(255) | Exposition du service applicatif  |
-| created_at  | timestamp    | Date de création                  |
-| updated_at  | timestamp    | Date de mise à jour               |
-| deleted_at  | timestamp    | Date de suppression               |
+| Champ       | Type         | Description                         |
+|:------------|:-------------|:------------------------------------|
+| id          | int unsigned | auto_increment                      |
+| name        | varchar(255) | Nom du service applicatif           |
+| description | longtext     | Description du service applicatif   |
+| exposition  | varchar(255) | Exposition du service applicatif    |
+| modules     | List int [,] | Liens vers les applications-modules |
+| applications | List int [,] | Liens vers les applications        |
+| created_at  | timestamp    | Date de création                    |
+| updated_at  | timestamp    | Date de mise à jour                 |
+| deleted_at  | timestamp    | Date de suppression                 |
 
 L'export du modèle de données référence les applications et les modules applicatifs rattachés à un service applicatif. 
 
@@ -577,14 +597,15 @@ d’informatique et une homogénéité technologique.
 
 Table *application_modules* :
 
-| Champ       | Type         | Description                      |
-|:------------|:-------------|:---------------------------------|
-| id          | int unsigned | auto_increment                   |
-| name        | varchar(255) | Nom du service applicatif        |
-| description | longtext     | Description du module applicatif |
-| created_at  | timestamp    | Date de création                 |
-| updated_at  | timestamp    | Date de mise à jour              |
-| deleted_at  | timestamp    | Date de suppression              |
+| Champ                | Type         | Description                          |
+|:---------------------|:-------------|:-------------------------------------|
+| id                   | int unsigned | auto_increment                       |
+| name                 | varchar(255) | Nom du service applicatif            |
+| description          | longtext     | Description du module applicatif     |
+| application_services | List int [,] | Liens vers les applications-services |
+| created_at           | timestamp    | Date de création                     |
+| updated_at           | timestamp    | Date de mise à jour                  |
+| deleted_at           | timestamp    | Date de suppression                  |
 
 L'export du modèle de données référence les services applicatifs rattachés à un module applicatif.  
 Dans l'application, un service applicatif peut être rattaché à un module applicatif depuis ces deux objets.
@@ -603,6 +624,7 @@ Table *databases* :
 | type               | varchar(255) | Type de technologie de la base de données |
 | entity_resp_id     | int unsigned | Entité responsable de la base de données  |
 | responsible        | varchar(255) | Responsable SSI de la base de données     |
+| icon_id            | int unsigned | Référence vers une image spécifique     |
 | security_need_c    | int          | Confidentialité                           |
 | security_need_i    | int          | Intégrité                                 |
 | security_need_a    | int          | Disponibilité                             |
@@ -646,8 +668,8 @@ Table *fluxes* :
 | name                  | varchar(255) | Nom du flux                               |
 | attributes            | varchar(255) | Attributs (tags) du flux                  |
 | description           | longtext     | Description du flux                       |
-| *device*_source_id    | int unsigned | Lien vers l'actif source                  |
-| *device*_dest_id      | int unsigned | Lien vers l'actif destinataire            |
+| ***device***_source_id    | int unsigned | Lien vers l'actif source                  |
+| ***device***_dest_id      | int unsigned | Lien vers l'actif destinataire            |
 | crypted               | tinyint(1)   | Le flux est chiffré (1=oui, O=non)        |
 | bidirectional         | tinyint(1)   | Le flux est bidirectionnel (1=oui, O=non) |
 | nature                | varcahr(255) | Nature du flux applicatif                 |
@@ -656,16 +678,18 @@ Table *fluxes* :
 | deleted_at            | timestamp    | Date de suppression                       |
 
 
-Les actifs sources et destination peuvent être :
+Les ***device*** sources et destination peuvent être :
 
-| Actif (*device*)                | Source   | Destination  |
-|:--------------------------------|:---------|:-------------|
-| Application                     | oui      | oui          |
-| Service applicatif              | oui      | oui          |
-| Module applicatif               | oui      | oui          |
-| Base de données                 | oui      | oui          |
+| Actif (*device*)                | Source | Destination |
+|:--------------------------------|:------:|:-----------:|
+| Application                     | ✅     | ✅          |
+| Service applicatif              | ✅     | ✅          |
+| Module applicatif               | ✅     | ✅          |
+| Base de données                 | ✅     | ✅          |
 
 Dans l'application, une information peut être rattaché à un flux applicatif depuis un objet flux applicatif.
+
+---
 
 ### L’administration
 
@@ -786,6 +810,8 @@ Table *admin_users* :
 L'export du modèle de données référence les applications dont un utilisateur est administrateur.  
 Dans l'application, un utilisateur peut être défini comme administrateur d'une application depuis un objet application.
 
+---
+
 ### L’infrastructure logique
 
 La vue de l'infrastructure logique correspond à la répartition logique du réseau.
@@ -888,7 +914,7 @@ Table *external_connected_entities* :
 | src                  | varchar(255) | Adresse(s) IP de connexion de l'entité                    |
 | src_desc             | varchar(255) | Description de la source de la connexion de l'entité      |
 | dst                  | varchar(255) | Adresse(s) IP ou plage de destination de la connexion     |
-| dst_desc             | varchar(255) | Description de la description de la connexion de l'entité |
+| dst_desc             | varchar(255) | Description de la connexion de l'entité                   |
 | security             | text         | Exigences de sécurité du système                          |
 | created_at           | timestamp    | Date de création                                          |
 | updated_at           | timestamp    | Date de mise à jour                                       |
@@ -1042,32 +1068,37 @@ est découpé en un seul serveur logique.
 
 Table *logical_servers* :
 
-| Champ                | Type         | Description                          |
-|:---------------------|:-------------|:-------------------------------------|
-| id                   | int unsigned | auto_increment                       |
-| name                 | varchar(255) | Nom du serveur                       |
-| icon_id              | int unsigned | Référence vers une image spécifique  |
-| type                 | varchar(255) | Type du serveur (appli, DB, etc.)    |
-| active               | tinyint(1)   | Serveur actif (1) ou obsolète (0)    |
-| attributes           | varchar(255) | Attributs (tages) du serveur         |
-| description          | longtext     | Description du serveur               |
-| operating_system     | varchar(255) | Système d'exploitation               |
-| install_date         | date         | Date d'installation du serveur       |
-| update_date          | date         | Date de mise à jour du serveur       |
-| environment          | varchar(255) | Environnement (prod, dev, test, ...) |
-| net_services         | varchar(255) | Services réseau actifs               |
-| address_ip           | varchar(255) | Adresses IP du serveur               |
-| domain_id            | int unsigned | Domaine d'administration du serveur  |
-| cpu                  | varchar(255) | Nombre de CPU                        |
-| memory               | varchar(255) | Quantité de mémoire                  |
-| disk                 | int          | Espace disque alloué                 |
-| disk_used            | int          | Espace disque utilisé                |
-| configuration        | longtext     | Configuration du serveur             |
-| patching_frequency   | int signed   | Fréquence des mises à jour           |
-| next_update          | date         | Date de la prochaine mise à jour     |
-| created_at           | timestamp    | Date de création                     |
-| updated_at           | timestamp    | Date de mise à jour                  |
-| deleted_at           | timestamp    | Date de suppression                  |
+| Champ                | Type         | Description                                       |
+|:---------------------|:-------------|:--------------------------------------------------|
+| id                   | int unsigned | auto_increment                                    |
+| name                 | varchar(255) | Nom du serveur                                    |
+| icon_id              | int unsigned | Référence vers une image spécifique               |
+| type                 | varchar(255) | Type du serveur (appli, DB, etc.)                 |
+| active               | tinyint(1)   | Serveur actif (1) ou obsolète (0)                 |
+| attributes           | varchar(255) | Attributs (tages) du serveur                      |
+| description          | longtext     | Description du serveur                            |
+| operating_system     | varchar(255) | Système d'exploitation                            |
+| install_date         | date         | Date d'installation du serveur                    |
+| update_date          | date         | Date de mise à jour du serveur                    |
+| patching_frequency   | int signed   | Fréquence des mises à jour                        |
+| next_update          | date         | Date de la prochaine mise à jour                  |
+| environment          | varchar(255) | Environnement (prod, dev, test, ...)              |
+| net_services         | varchar(255) | Services réseau actifs                            |
+| address_ip           | varchar(255) | Adresses IP du serveur                            |
+| domain_id            | int unsigned | Domaine d'administration du serveur               |
+| cpu                  | varchar(255) | Nombre de CPU                                     |
+| memory               | varchar(255) | Quantité de mémoire                               |
+| disk                 | int          | Espace disque alloué                              |
+| disk_used            | int          | Espace disque utilisé                             |
+| configuration        | longtext     | Configuration du serveur                          |
+| databases            | List int [,] | Liste d'id de(s) database(s) liée(s)              |
+| cluster_id           | List int [,] | Liste d'id de(s) lien(s) cluster(s)               |
+| physical_servers     | List int [,] | Liste d'id de(s) serveur(s) physiques(s) associés |
+| applications         | List int [,] | Liste d'id de(s) aplication(s) hebergée(s)        |
+| containers           | List int [,] | Liste d'id de(s) containers hebergé(s)            |
+| created_at           | timestamp    | Date de création                                  |
+| updated_at           | timestamp    | Date de mise à jour                               |
+| deleted_at           | timestamp    | Date de suppression                               |
 
 Les champs "patching_frequency" et "next_update" ne sont pas utilisés pour le moment et sont donc absents de l'application.  
 L'export du modèle de données référence : 
@@ -1148,16 +1179,16 @@ Principe général :
 
 Les actifs sources et destination peuvent être :
 
-| Actif (*device*)                | Source   | Destination  |
-|:--------------------------------|:---------|:-------------|
-| Périphérique                    | oui      | oui          |
-| Equipement de sécurité physique | oui      | oui          |
-| Serveur physique                | oui      | oui          |
-| Infrastructure de stockage      | oui      | oui          |
-| Poste de travail                | oui      | oui          |
-| Equipement de sécurité logique  | oui      | oui          |
-| Serveur logique                 | oui      | oui          |
-| Sous-réseaux                    | oui      | oui          |
+| Actif (*device*)                | Source  | Destination |
+|:--------------------------------|:-------:|:-----------:|
+| Périphérique                    | ✅      | ✅          |
+| Equipement de sécurité physique | ✅      | ✅          |
+| Serveur physique                | ✅      | ✅          |
+| Infrastructure de stockage      | ✅      | ✅          |
+| Poste de travail                | ✅      | ✅          |
+| Equipement de sécurité logique  | ✅      | ✅          |
+| Serveur logique                 | ✅      | ✅          |
+| Sous-réseaux                    | ✅      | ✅          |
 
 #### Certificats
 
@@ -1213,6 +1244,8 @@ L'export du modèle de données référence les routeurs physiques et les commut
 rattachés à un VLAN.
 Dans l'application, un VLAN peut être rattaché à un routeur physique depuis un objet routeur physique.  
 Dans l'application, un VLAN peut être rattaché à un sous-réseau ou un commutateur logique depuis ces deux objets.
+
+---
 
 ### L’infrastructure physique
 
@@ -1288,29 +1321,31 @@ Les serveurs physiques sont des machines physiques exécutant un ensemble de ser
 
 Table *physical_servers* :
 
-| Champ                | Type         | Description                           |
-|:---------------------|:-------------|:--------------------------------------|
-| id                   | int unsigned | auto_increment                        |
-| name                 | varchar(255) | Nom du serveur                        |
-| icon_id              | int unsigned | Référence vers une image spécifique   |
-| description          | longtext     | Description du serveur                |
-| type                 | varchar(255) | Type / modèle du serveur              |
-| cpu                  | varchar(255) | Processeur(s) du serveur              |
-| memory               | varchar(255) | RAM / mémoive vive du serveur         |
-| disk                 | varchar(255) | Stockage du serveur                   | 
-| disk_used            | varchar(255) | Stockage utilisé du serveur           |
-| configuration        | longtext     | Configuration du serveur              |
-| operating_system     | varchar(255) | Système d'exploitaion du serveur      |
-| install_date         | datetime     | Date d'installation du serveur        |
-| update_date          | datetime     | Date de mise à jour du serveur        |
-| responsible          | varchar(255) | Responsable d'exploitation du serveur |
-| address_ip           | varchar      | Adresse(s) IP du serveur              |
-| site_id              | int unsigned | Référence vers le site                |
-| building_id          | int unsigned | Référence vers le building / salle    |
-| bay_id               | int unsigned | Référence vers la baie                |
-| created_at           | timestamp    | Date de création                      |
-| updated_at           | timestamp    | Date de mise à jour                   |
-| deleted_at           | timestamp    | Date de suppression                   |
+| Champ                | Type         | Description                                          |
+|:---------------------|:-------------|:-----------------------------------------------------|
+| id                   | int unsigned | auto_increment                                       |
+| name                 | varchar(255) | Nom du serveur                                       |
+| icon_id              | int unsigned | Référence vers une image spécifique                  |
+| description          | longtext     | Description du serveur                               |
+| type                 | varchar(255) | Type / modèle du serveur                             |
+| cpu                  | varchar(255) | Processeur(s) du serveur                             |
+| memory               | varchar(255) | RAM / mémoive vive du serveur                        |
+| disk                 | varchar(255) | Stockage du serveur                                  | 
+| disk_used            | varchar(255) | Stockage utilisé du serveur                          |
+| configuration        | longtext     | Configuration du serveur                             |
+| operating_system     | varchar(255) | Système d'exploitaion du serveur                     |
+| install_date         | datetime     | Date d'installation du serveur                       |
+| update_date          | datetime     | Date de mise à jour du serveur                       |
+| responsible          | varchar(255) | Responsable d'exploitation du serveur                |
+| address_ip           | varchar      | Adresse(s) IP du serveur                             |
+| site_id              | int unsigned | Référence vers le site                               |
+| building_id          | int unsigned | Référence vers le building / salle                   |
+| bay_id               | int unsigned | Référence vers la baie                               |
+| clusters             | List int [,] | Liste des id de(s) cluster(s) associé(s)             |
+| logical_servers      | List int [,] | Liste des id de(s) logical(s) serveurs(s) associé(s) |
+| created_at           | timestamp    | Date de création                                     |
+| updated_at           | timestamp    | Date de mise à jour                                  |
+| deleted_at           | timestamp    | Date de suppression                                  |
 
 L'export du modèle de données référence les applications, les clusters (logiques) et les serveurs 
 logiques rattachés à un serveur physique.  
@@ -1601,20 +1636,20 @@ Principe général :
 
 Les actifs sources et destination peuvent être :
 
-| Actif                           | Source | Destination |
-|:--------------------------------|:-------|:------------|
-| Périphérique                    | oui    | oui         |
-| Téléphone                       | oui    | oui         |
-| Routeur physique                | oui    | oui         |
-| Equipement de sécurité physique | oui    | oui         |
-| Serveur physique                | oui    | oui         |
-| Commutateur physique            | oui    | oui         |
-| Infrastructure de stockage      | oui    | oui         |
-| Borne Wifi                      | oui    | oui         |
-| Poste de travail                | oui    | oui         |
-| Serveur logique                 | oui    | oui         |
-| Commutateur logique             | oui    | oui         |
-| Routeur logique                 | oui    | oui         |
+| Actif                           | Source  | Destination |
+|:--------------------------------|:-------:|:-----------:|
+| Périphérique                    | ✅      | ✅          |
+| Téléphone                       | ✅      | ✅          |
+| Routeur physique                | ✅      | ✅          |
+| Equipement de sécurité physique | ✅      | ✅          |
+| Serveur physique                | ✅      | ✅          |
+| Commutateur physique            | ✅      | ✅          |
+| Infrastructure de stockage      | ✅      | ✅          |
+| Borne Wifi                      | ✅      | ✅          |
+| Poste de travail                | ✅      | ✅          |
+| Serveur logique                 | ✅      | ✅          |
+| Commutateur logique             | ✅      | ✅          |
+| Routeur logique                 | ✅      | ✅          |
 
 #### WAN
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -14,21 +14,41 @@ The register of processing activities contains the information required by artic
 
 Table *data_processing* :
 
-| Field | Type | Description |
-|:------------|:-------------|:---------------------|
-| id | int unsigned | auto_increment |
-| name | varchar(255) | Processing name |
-| description | longtext | Processing description |
-| responsible | longtext | Responsible person for processing |
-| purpose | longtext | Purposes of processing |
-| categories | longtext | Categories of recipients |
-| recipients | longtext | Data recipients |
-| transfer | longtext | Data transfers |
-| retention | longtext | Retention periods |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field                          | Type         | Description                             |
+|:-------------------------------|:-------------|:----------------------------------------|
+| id                             | int unsigned | auto_increment                          |
+| name                           | varchar(255) | Processing name                         |
+| description                    | longtext     | Processing description                  |
+| legal_basis                    | varchar(255) | Legal basis for processing              |
+| responsible                    | longtext     | Responsible person for processing       |
+| purpose                        | longtext     | Purposes of processing                  |
+| lawfulness                     | text         | Legality of processing                  |
+| lawfulness_consent             | tinyint(1)   | Legality based on consent               |
+| lawfulness_contract            | tinyint(1)   | Contractual legality                    |
+| lawfulness_legal_obligation    | tinyint(1)   | Legality based on legal obligation      |
+| lawfulness_vital_interest      | tinyint(1)   | Legality based on vital interest        |
+| lawfulness_public_interest     | tinyint(1)   | Legality based on public interest       |
+| lawfulness_legitimate_interest | tinyint(1)   | Legality based on legitimate interest   |
+| categories                     | longtext     | Categories of recipients                |
+| recipients                     | longtext     | Data recipients                         |
+| transfer                       | longtext     | Data transfers                          |
+| retention                      | longtext     | Retention periods                       |
+| controls                       | longtext     | Security Measures                       |
+| created_at                     | timestamp    | Date of creation                        |
+| updated_at                     | timestamp    | Date of update                          |
+| deleted_at                     | timestamp    | Date of deletion                        |
 
+The "controls" field is not used and is not implemented yet in mercator.
+
+Data model export references processes, information, applications and documents 
+related to data processing.  
+
+In the application, a process can be linked to data processing from a processing object 
+of data.  
+Information can be linked to data processing from a data processing object.
+
+An application can be linked to data processing from a data processing object.  
+A document can be attached to data processing from a data processing object.  
 
 #### Security measures
 
@@ -65,21 +85,32 @@ Entities are departments, suppliers, partners with whom information is exchanged
 
 Table *entities* :
 
-| Field             | Type         | Description |
-|:------------------|:-------------|:-----------------|
-| id                | int unsigned | Unique identifier of the entity |
-| name              | varchar(255) | Name of entity |
-| entity_type       | varchar(255) | Type of entity |
-| attributes        | varchar(255) | Attributes (#tag...) |
+| Field             | Type         | Description                              |
+|:------------------|:-------------|:-----------------------------------------|
+| id                | int unsigned | Unique identifier of the entity          |
+| name              | varchar(255) | Name of entity                           |
+| icon_id           | int unsigned | Reference to a specific image            |
+| entity_type       | varchar(255) | Type of entity                           |
+| attributes        | varchar(255) | Attributes (#tag...)                     |
+| description       | longtext     | Entity description                       |
 | reference         | varchar(255) | Reference number of the entity (billing) |
-| parent_entity_id  | int unsigned | Pointer to the parent entity |
-| is_external       | boolean       | External entity |
-| security_level    | longtext      | Security level |
-| contact_point     | longtext      | Contact point |
-| description       | longtext      | Entity description |
-| created_at        | timestamp     | Date of creation |
-| updated_at        | timestamp     | Date of update |
-| deleted_at        | timestamp     | Date of deletion |
+| parent_entity_id  | int unsigned | Pointer to the parent entity             |
+| is_external       | boolean      | External entity                          |
+| security_level    | longtext     | Security level                           |
+| contact_point     | longtext     | Contact point                            |
+| created_at        | timestamp    | Date of creation                         |
+| updated_at        | timestamp    | Date of update                           |
+| deleted_at        | timestamp    | Date of deletion                         |
+
+The "external_ref_id" field is not used and is therefore missing from the application.  
+
+Exporting the data model references the processes and applications attached to an entity.
+
+In the application, a process can be attached to an entity from these two objects.  
+An application can be attached to an entity (as operations manager) from these two objects.
+
+In the application, a database can be attached to an entity (as operations manager)
+from these two objects. 
 
 #### Relationships
 
@@ -89,30 +120,42 @@ Relationships are contracts, service agreements, legal obligations... that have 
 
 Table *relations* :
 
-| Field         | Type | Description |
-|:--------------|:-------------|:-----------------|
-| id            | int unsigned | auto_increment |
-| name          | varchar(255) | Relationship name |
-| type          | varchar(255) | Type of relationship |
-| attributes      | varchar(255) | Attributes (#tag...) |
-| description   | longtext | Description of relationship |
-| source_id     | int unsigned | Reference to source entity |
-| destination_id | int unsigned | Reference to destination entity |
-| reference       | varchar(255) | Reference number of the relation (billing) |
-| responsible     | varchar(255) | Responsible of the relation |
-| order_number    | varchar(255) | Ordre number (billing) |
-| active          | tinyint(1)   | Is the reation still active |
-| start_date      | date         | Start date of the relation |
-| end_date        | date         | End date of the relation |
-| comments        | text         | Comment on the status of the relation |
-| importance      | int          | Importance of relationship |
-| security_need_c | int          | Confidentiality level need |
-| security_need_i | int          | Integrity level need  |
-| security_need_a | int          | Available level need |
-| security_need_t | int          | Traceability level need  |
-| created_at    | timestamp | Date of creation |
-| updated_at    | timestamp | Date of update |
-| deleted_at    | timestamp | Date of deletion |
+| Field              | Type         | Description                                |
+|:-------------------|:-------------|:-------------------------------------------|
+| id                 | int unsigned | auto_increment                             |
+| name               | varchar(255) | Relationship name                          |
+| type               | varchar(255) | Type of relationship                       |
+| attributes         | varchar(255) | Attributes (#tag...)                       |
+| description        | longtext     | Description of relationship                |
+| source_id          | int unsigned | Reference to source entity                 |
+| destination_id     | int unsigned | Reference to destination entity            |
+| reference          | varchar(255) | Reference number of the relation (billing) |
+| responsible        | varchar(255) | Responsible of the relation                |
+| order_number       | varchar(255) | Ordre number (billing)                     |
+| active             | tinyint(1)   | Is the reation still active                |
+| start_date         | date         | Start date of the relation                 |
+| end_date           | date         | End date of the relation                   |
+| comments           | text         | Comment on the status of the relation      |
+| importance         | int          | Importance of relationship                 |
+| security_need_c    | int          | Confidentiality level need                 |
+| security_need_i    | int          | Integrity level need                       |
+| security_need_a    | int          | Available level need                       |
+| security_need_t    | int          | Traceability level need                    |
+| security_need_auth | int          | Need for authenticity                      |
+| created_at         | timestamp    | Date of creation                           |
+| updated_at         | timestamp    | Date of update                             |
+| deleted_at         | timestamp    | Date of deletion                           |
+
+In the app, the need for authenticity, "security_need_auth", is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu.  
+
+exporting the data model references the reference documents attached to a relationship.  
+In the application, a document can be attached to a relationship from a relationships object. 
+
+The financial values of a contract can be indicated in dedicated fields.  
+
+---
 
 ### Business view of the information system
 
@@ -138,11 +181,17 @@ Table *macro_processuses* :
 | security_need_i | int | Integrity |
 | security_need_a | int | Availability |
 | security_need_t | int | Traceability |
+| security_need_auth | int          | Authenticité                   |
 | owner | varchar(255) | Owner |
 | created_at | timestamp | Date of creation |
 | updated_at | timestamp | Date of update |
 | deleted_at | timestamp | Date of deletion |
 
+In the app, the need for authenticity, "security_need_auth", is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu.  
+
+In the application, a process can be attached to a macro-process from these two objects.
 
 #### Processes
 
@@ -152,21 +201,53 @@ Processes are made up of activities, the entities involved in the process, and t
 
 Table *processes* :
 
-| Field | Type | Description |
-|:----------------|:-------------|:-----------------|
-| id | int unsigned | auto_increment |
-| identifier | varchar(255) | Process name |
-| description | longtext | Process description |
-| owner | varchar(255) | Process owner |
-| in_out | longtext | incoming and outgoing elements |
-| security_need_c | int | Confidentiality |
-| security_need_i | int | Integrity |
-| security_need_a | int | Availability |
-| security_need_t | int | Traceability |
-| macroprocess_id | int unsigned | Reference to macro-process |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field              | Type         | Description                         |
+|:-------------------|:-------------|:------------------------------------|
+| id                 | int unsigned | auto_increment                      |
+| name               | varchar(255) | Process name                        |
+| description        | longtext     | Process description                 |
+| icon_id            | int unsigned | Reference to a specific image       |
+| owner              | varchar(255) | Process owner                       |
+| in_out             | longtext     | incoming and outgoing elements      |
+| security_need_c    | int          | Confidentiality                     |
+| security_need_i    | int          | Integrity                           |
+| security_need_a    | int          | Availability                        |
+| security_need_t    | int          | Traceability                        |
+| macroprocess_id    | int unsigned | Reference to macro-process          |
+| activities         | List int [,] | IDs list of related activities      |
+| entities           | List int [,] | IDs list of related entities        |
+| informations       | List int [,] | IDs list of related informations    |
+| applications       | List int [,] | IDs list of related applications    |
+| operations         | List int [,] | IDs list of related operations      |
+| created_at         | timestamp    | Date of creation                    |
+| updated_at         | timestamp    | Date of update                      |
+| deleted_at         | timestamp    | Date of deletion                    |
+
+In the app, the need for authenticity, "security_need_auth", is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu.  
+
+The export of the data model references:
+
+- entities,
+- activities,
+- information,
+- applications,
+- data processing,
+- and security measures
+
+linked to a process.
+
+In the application, an entity associated with a process can be attached to a process from these two objects.  
+An activity can be linked to a process from these two objects.  
+Information can be linked to a process from these two objects.  
+
+An application can be attached to a process from these two objects.  
+GDPR registry processing can be attached to a process from a registry processing object.  
+
+A security measure can be attached to an application from the "Assign a security measure" button.  
+This button is present in the GDPR view and visible in the list of Security Measures objects.
+
 
 #### Activities
 
@@ -174,14 +255,43 @@ An activity is a step required to carry out a process. It corresponds to a speci
 
 Table *activities* :
 
-| Field | Type | Description |
-|:----------------|:-------------|:-----------------|
-| id | int unsigned | auto_increment |
-| name | varchar(255) | activity name |
-| description | longtext | Activity description |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field                       | Type         | Description |
+|:----------------------------|:-------------|:-----------------|
+| id                          | int unsigned | auto_increment |
+| name                        | varchar(255) | activity name |
+| description                 | longtext     | Activity description |
+| recovery_time_objective     | int signed   | RTO, Target time for activity recovery           |
+| maximum_tolerable_downtime  | int signed   | Maximum Tolerable Disturbance Duration           |
+| recovery_point_objective    | int signed   | RPO, Data Restore Time Point                     |
+| maximum_tolerable_data_loss | int signed   | Maximum Allowable Data Loss                |     |
+| drp                         | text         | Description of the business recovery plan (DRP)  |
+| drp_link                    | varchar(255) | Link (URL) to the DRP                            |
+| created_at                  | timestamp    | Date of creation |
+| updated_at                  | timestamp    | Date of update |
+| deleted_at                  | timestamp    | Date of deletion |
+
+In the application, the "Impact Type" and "Gravity" fields are managed in a separate table.
+
+
+##### Impacts
+
+Impacts are the consequences of the occurrence of a risk during an activity.
+
+Impacts are only accessible through activity objects.  
+
+They are neither importable nor exportable through the graphics tool.  
+
+Table *activity_impact* :
+
+| Champ            | Type          | Description                                              |
+|:-----------------|:--------------|:---------------------------------------------------------|
+| id               | bigint signed | auto_increment                                           |
+| activity_id      | int unsigned  | Link to the activity related to this impact              |
+| impact_type      | varchar(255)  | Kind of impact (finance, brand, environnement, other...) |
+| severity         | tinyint(4)    | Impact description                                       |
+| created_at       | timestamp     | Date of creation                                         |
+| updated_at       | timestamp     | Date of update                                           |
+
 
 #### Operations
 
@@ -189,15 +299,24 @@ An operation is made up of actors and tasks.
 
 Table *operations* :
 
-| Field | Type | Description |
-|:----------------|:-------------|:-----------------|
-| id | int unsigned | auto_increment |
-| name | varchar(255) | Name of operation |
-| description | longtext | Description of operation |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field       | Type         | Description                                             |
+|:------------|:-------------|:--------------------------------------------------------|
+| id          | int unsigned | auto_increment                                          |
+| name        | varchar(255) | Name of operation                                       |
+| description | longtext     | Description of operation                                |
+| process_id  | int unsigned | Reference to the process of which the operation is part |
+| actors      | List int [,] | IDs list of related actors                              |
+| tasks       | List int [,] | IDs list of related tasks                               |
+| activities  | List int [,] | IDs list of related activities                          |
+| created_at  | timestamp    | Date of creation |
+| updated_at  | timestamp    | Date of update |
+| deleted_at  | timestamp    | Date of deletion |
 
+The export of the data model references the activities, actors and tasks linked to an operation.  
+
+In the application, an activity can be linked to an operation from these two objects.  
+An actor can be attached to an operation from the operations object.  
+A task can be attached to an operation from the operations object.  
 
 #### Tasks
 
@@ -214,22 +333,27 @@ Table *tasks* :
 | updated_at | timestamp | Date of update |
 | deleted_at | timestamp | Date of deletion |
 
+Exporting the data model references operations related to a task. In the application.
+
+An operation can be attached to a task from the operations object.
+
 #### Actors
 
 An actor is a representative of a business role who performs operations, uses applications and makes decisions within processes. This role can be carried by a person, a group of people or an entity.
 
 Table *actors* :
 
-| Field | Type | Description |
-|:----------------|:-------------|:-----------------|
-| id | int unsigned | auto_increment |
-| name | varchar(255) | actor's name |
-| nature | varchar(255) | Nature of actor |
-| type | varchar(255) | Type of actor |
-| contact | varchar(255) | Actor contact |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field      | Type         | Description |
+|:-----------|:-------------|:-----------------|
+| id         | int unsigned | auto_increment |
+| name       | varchar(255) | actor's name |
+| nature     | varchar(255) | Nature of actor |
+| type       | varchar(255) | Type of actor |
+| contact    | varchar(255) | Actor contact |
+| operations | List int [,] | IDs list of related operations |
+| created_at | timestamp    | Date of creation |
+| updated_at | timestamp    | Date of update |
+| deleted_at | timestamp    | Date of deletion |
 
 #### Information
 
@@ -237,23 +361,34 @@ Information is data that is processed by a computer.
 
 Table *information* :
 
-| Field | Type | Description |
-|:----------------|:-------------|:-----------------|
-| id | int unsigned | auto_increment |
-| name | varchar(255) | Name of information |
-| description | longtext | Description of information |
-| owner | varchar(255) | Owner of information |
-| administrator | varchar(255) | Information administrator |
-| storage | varchar(255) | Information storage |
-| security_need_c | int | Confidentiality |
-| security_need_i | int | Integrity |
-| security_need_a | int | Availability |
-| security_need_t | int | Traceability |
-| sensitivity | varchar(255) | Sensitivity of information |
-| constraints | longtext | Legal and regulatory constraints |
-| created_at | timestamp | Date of creation |
-| updated_at | timestamp | Date of update |
-| deleted_at | timestamp | Date of deletion |
+| Field              | Type         | Description |
+|:-------------------|:-------------|:-----------------|
+| id                 | int unsigned | auto_increment |
+| name               | varchar(255) | Name of information |
+| description        | longtext     | Description of information |
+| owner              | varchar(255) | Owner of information |
+| administrator      | varchar(255) | Information administrator |
+| sensitivity        | varchar(255) | Sensitivity of information |
+| storage            | varchar(255) | Information storage |
+| security_need_c    | int          | Confidentiality |
+| security_need_i    | int          | Integrity |
+| security_need_a    | int          | Availability |
+| security_need_t    | int          | Traceability |
+| security_need_auth | int          | Authenticité                     |
+| constraints        | longtext     | Legal and regulatory constraints |
+| retention          | varchar(255) | Information retention period     |
+| created_at         | timestamp    | Date of creation |
+| updated_at         | timestamp    | Date of update |
+| deleted_at         | timestamp    | Date of deletion |
+
+The "retention" field is not used at the moment and is therefore absent from the application. 
+
+In the app, the need for authenticity is hidden by default. It is mandatory in the case from an entity subject to EU Directive 2022/2554 (DORA).
+It is activated from the Configuration > Settings menu. 
+
+The export of the data model references the databases and processes attached to information. In the application, a database can be attached to information from the database object. A process can be linked to information from these two objects.
+
+---
 
 ### Application view
 
@@ -292,39 +427,110 @@ When there is no virtualized environment, there are not several logical servers 
 Table *m_applications* :
 
 
-| Champ           | Type         | Description      |
-|:----------------|:-------------|:-----------------|
-| id                  | int unsigned | auto_increment |
-| name                | varchar(255) | Name of the application |
-| version             | varchar(255) | Version of the application |        
-| description         | longtext     | Description |
-| security_need_c     | int          | Confidentiality |
-| security_need_i     | int          | Integrity |
-| security_need_a     | int          | Availability |
-| security_need_t     | int          | Traceability |
-| ecurity_need_auth     | int          | Authenticity |
-| type            | varchar(255) | Type of application |
-| attributes      | varchar(255) | Attributes of the application |
-| technology      | varchar(255) | Technology |
-| external        | varchar(255) | External |
-| users           | varchar(255) | Number of users and type |
-| documentation   | varchar(255) | Link to documentation |
-| entity_resp_id  | int unsigned | Entity responsible |
-| responsible         | varchar(255) | Person/team responsible |
-| functional_referent        | varchar(255) | Functional referent |
-| editor         | varchar(255) | Application's editor |
+| Champ                | Type         | Description      |
+|:---------------------|:-------------|:-----------------|
+| id                   | int unsigned | auto_increment |
+| name                 | varchar(255) | Name of the application |
 | application_block_id | int unsigned | Group of application |
-| install_date    | datetime    | Date of installation |
-| update_date     | datetime    | Date of upgrade |
-| next_update     | datetime    | Date of next planned upgrade |
-| rto             | int          | Recovery Time Objective |
-| rpo             | int          | Recovery Point Objective |
-| vendor         | varchar(255) | Application's vendor |
-| product         | varchar(255) | Product name |
-| patching_frequency        | int | Patching frequency |
-| created_at      | timestamp    | Date of creation |
-| updated_at      | timestamp    | Date of update |
-| deleted_at      | timestamp    | Date of deletion |
+| attributes           | varchar(255) | Attributes of the application |
+| description          | longtext     | Description |
+| icon_id              | int unsigned | Reference to a specific image         |
+| responsible          | varchar(255) | Person/team responsible |
+| functional_referent  | varchar(255) | Functional referent |
+| editor               | varchar(255) | Application's editor |
+| users                | varchar(255) | Number of users and type |
+| technology           | varchar(255) | Technology |
+| type                 | varchar(255) | Type of application |
+| external             | varchar(255) | External |
+| install_date         | datetime     | Date of installation |
+| update_date          | datetime     | Date of upgrade |
+| next_update          | datetime     | Date of next planned upgrade |
+| documentation        | varchar(255) | Link to documentation |
+| security_need_c      | int          | Confidentiality |
+| security_need_i      | int          | Integrity |
+| security_need_a      | int          | Availability |
+| security_need_t      | int          | Traceability |
+| ecurity_need_auth    | int          | Authenticity |
+| rto                  | int          | Recovery Time Objective |
+| rpo                  | int          | Recovery Point Objective |
+| vendor               | varchar(255) | Application's vendor |
+| product              | varchar(255) | Product name |
+| version              | varchar(255) | Version of the application |
+| patching_frequency   | int          | Patching frequency |
+| entities             | List int [,] | IDs list of related entities         |
+| processes            | List int [,] | IDs list of related processes        |
+| services             | List int [,] | IDs list of related services         |
+| databases            | List int [,] | IDs list of related dataabses        |
+| logical_servers      | List int [,] | IDs list of related logical_servers  |
+| activities           | List int [,] | IDs list of related activities       |
+| created_at           | timestamp    | Date of creation |
+| updated_at           | timestamp    | Date of update |
+| deleted_at           | timestamp    | Date of deletion |
+
+RTO : *Recovery Time Objective*  
+RPO : *Recovery Point Objective*  
+
+The "patching_frequency" and "next_update" fields are not used at the moment and are therefore missing from the application.  
+
+In the app, the need for authenticity is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu. 
+
+'export of reference data model:
+
+- user entities (*entities* field),
+- supported processes,
+- supported activities,
+- application services,
+- databases,
+- workstations,
+- logical servers,
+- logical safety equipment,
+- administrators (Users object of the administration view),
+- and security measures
+
+attached to an application.
+
+In the application, a user entity can be attached to an application from an application object.  
+A process can be attached to an application from these two objects.  
+An activity can be attached to an application from these two objects.  
+
+
+An application service can be attached to an application from these two objects.  
+A database can be attached to an application from these two objects.  
+A workstation can be attached to an application from a workstation object.  
+
+
+A logical server can be attached to an application from these two objects.  
+Logical security equipment can be attached to an application from these two objects.  
+An administrator can be attached to an application from an application object.  
+
+
+A security measure can be attached to an application from the "Assign a security measure" button.  
+This button is present in the GDPR view and visible in the list of Security Measures objects.  
+
+
+In the application, a container can be attached to an application from these two objects.  
+In the application, the *major events* field is managed in a separate table.
+
+
+#### Major events
+
+Major events are the main events experienced by an application during its operation.  
+Major events are only accessible through application objects.  
+
+They are neither importable nor exportable through the graphics tool.  
+
+Table *m_application_events* :
+
+| Champ            | Type         | Description                                         |
+|:-----------------|:-------------|:----------------------------------------------------|
+| id               | int unsigned | auto_increment                                      |
+| user_id          | int unsigned | Mercator user id who has register the event            |
+| m_application_id | varchar(255) | Reference to the id of the application that suffered the event |
+| message          | longtext     | Description of the event                          |
+| created_at       | timestamp    | Date de création                                    |
+| updated_at       | timestamp    | Date de mise à jour                                 |
 
 
 #### Application services
@@ -341,10 +547,20 @@ Table *application_services* :
 | name            | varchar(255) | Name of the application service |
 | description     | longtext     | Description of the application service |
 | exposition      | varchar(255) | Exposure of the application service |
+| modules         | List int [,] | Liens vers les applications-modules |
+| applications    | List int [,] | Liens vers les applications        |
 | created_at      | timestamp    | Date of creation |
 | updated_at      | timestamp    | Date of update |
 | deleted_at      | timestamp    | Date of deletion |
 
+The export of the data model references the applications and application modules attached to an application service. 
+
+In the application, an application can be attached to an application service from these two objects.  
+In the application, an application module can be attached to an application service from these two objects.  
+
+There are two fields with the same information in the data model export, *servicesApplications* and 
+*applications*.  
+The connection with application objects is made via the *applications* field.
 
 #### Application module
 
@@ -352,15 +568,18 @@ An application module is a component of an application characterized by function
 
 Table *application_modules* :
 
-| Champ           | Type         | Description      |
-|:----------------|:-------------|:-----------------|
-| id              | int unsigned | auto_increment |
-| name            | varchar(255) | Name of the application module |
-| description     | longtext     | Description of the application module |
-| created_at      | timestamp    | Date of creation |
-| updated_at      | timestamp    | Date of update |
-| deleted_at      | timestamp    | Date of deletion |
+| Champ                | Type         | Description      |
+|:---------------------|:-------------|:-----------------|
+| id                   | int unsigned | auto_increment |
+| name                 | varchar(255) | Name of the application module |
+| description          | longtext     | Description of the application module |
+| application_services | List int [,] | IDs list of related to applications-services |
+| created_at           | timestamp    | Date of creation |
+| updated_at           | timestamp    | Date of update |
+| deleted_at           | timestamp    | Date of deletion |
 
+The export of the data model references the application services attached to an application module.  
+In the application, an application service can be attached to an application module from these two objects.
 
 #### Database
 
@@ -368,22 +587,40 @@ A collection of databases managed within the organisation.
 
 Table *databases* :
 
-| Champ           | Type         | Description      |
-|:----------------|:-------------|:-----------------|
-| id              | int unsigned | auto_increment |
-| name            | varchar(255) | Name of the database |
-| description     | longtext     | Description of the database |
-| responsible     | varchar(255) | Responsible entity |
-| type            | varchar(255) | Responsible person/team |
-| security_need_c | int          | Confidentiality |
-| security_need_i | int          | Integrity |
-| security_need_a | int          | Availability |
-| security_need_t | int          | Traceability |
-| external        | varchar(255) | External |
-| entity_resp_id  | int unsigned | Entité responsable  |
-| created_at      | timestamp    | Date of creation |
-| updated_at      | timestamp    | Date of update |
-| deleted_at      | timestamp    | Date of deletion |
+| Champ               | Type         | Description      |
+|:-------------------|:-------------|:-----------------|
+| id                 | int unsigned | auto_increment |
+| name               | varchar(255) | Name of the database |
+| description        | longtext     | Description of the database |
+| type               | varchar(255) | Technology used |
+| entity_resp_id     | int unsigned | Entité responsable  |
+| responsible        | varchar(255) | Responsible entity |
+| icon_id            | int unsigned | Reference to a specific image            |
+| security_need_c    | int          | Confidentiality |
+| security_need_i    | int          | Integrity |
+| security_need_a    | int          | Availability |
+| security_need_t    | int          | Traceability |
+| security_need_auth | int          | Authenticité                              |
+| external           | varchar(255) | External |
+| created_at         | timestamp    | Date of creation |
+| updated_at         | timestamp    | Date of update |
+| deleted_at         | timestamp    | Date of deletion |
+
+In the app, the need for authenticity is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu. 
+
+Exporting the data model references the specific image of a database.  
+In the application, a specific image can be attached to a database from a database object.  
+
+The data model export references user entities (*entities* field), applications, information,
+logical servers and containers attached to a database.  
+In the application, a user entity can be attached to a database from a database object.  
+In the application, information can be attached to a database from a database object.  
+In the application, an application can be attached to a database from these two objects.  
+In the application, a logical server can be attached to a database from these two objects.  
+In the application, a container can be attached to a database from these two objects.
+
 
 #### Flow
 
@@ -399,20 +636,27 @@ Table *fluxes* :
 |:----------------------|:-------------|:-----------------|
 | id                    | int unsigned | auto_increment |
 | name                  | varchar(255) | Name of the flow |
+| attributes            | varchar(255) | Attributs (tags) du flux                  |
 | description           | longtext     | Description of the flow |
-| application_source_id | int unsigned | Link to source application |
-| service_source_id     | int unsigned | Link to source service |
-| module_source_id      | int unsigned | Link to source module |
-| database_source_id    | int unsigned | Link to source database |
-| application_dest_id   | int unsigned | Link to destination application  |
-| service_dest_id       | int unsigned | Link to destination service |
-| module_dest_id        | int unsigned | Link to destination module |
-| database_dest_id      | int unsigned | Link to destination database |
+| ***device***_source_id    | int unsigned | Link to the source_id                 |
+| ***device***_dest_id      | int unsigned | Lnk to the destination id          |
 | crypted               | tinyint(1)   | The flow is encrypted (1=yes, O=no) |
 | bidirectional         | tinyint(1)   | The flow is bydirectional (1=yes, O=no)|
 | created_at            | timestamp    | Date of creation |
 | updated_at            | timestamp    | Date of update |
 | deleted_at            | timestamp    | Date of deletion |
+
+The  ***device***_ for source_id or dest_id might be: :
+
+| Actif (*device*)                | Source | Destination |
+|:--------------------------------|:------:|:-----------:|
+| Application                     | ✅     | ✅          |
+| Application service             | ✅     | ✅          |
+| Application module              | ✅     | ✅          |
+| Database                        | ✅     | ✅          |
+
+
+---
 
 ### Administration
 
@@ -474,6 +718,8 @@ Table *forest_ads* :
 | updated_at            | timestamp    | Date of update |
 | deleted_at            | timestamp    | Date of deletion |
 
+---
+
 ### Logical infrastructure
 
 The logical infrastructure view corresponds to the logical distribution of the network.
@@ -500,9 +746,14 @@ Table *networks* :
 | security_need_i | int          | Integrity |
 | security_need_a | int          | Availability |
 | security_need_t | int          | Traceability |
+| security_need_auth | int       | Authenticité                  |
 | created_at      | timestamp    | Date of creation |
 | updated_at      | timestamp    | Date of update |
 | deleted_at      | timestamp    | Date of deletion |
+
+In the app, the need for authenticity is hidden by default. It is mandatory in the case 
+from an entity subject to EU Directive 2022/2554 (DORA).  
+It is activated from the Configuration > Settings menu. 
 
 #### Subnetworks
 
@@ -515,20 +766,23 @@ table *subnetworks* :
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the subnet |
 | description          | longtext     | Description of the subnet |
+| network_id           | int unsigned | ID related to parent network |
+| subnetwork_id        | int unsigned | ID related to child network  |
+| connected_subnets_id | int unsigned | Network to which this subnet belongs |
 | address              | varchar(255) | Addresses range |
 | default_gateway      | varchar(255) | Default gateway |
+| gateway_id           | int unsigned | Gateway |
+| vlan_id              | int unsigned | Associated VLAN |
 | ip_allocation_type   | varchar(255) | Type of IP address allocation |
-| responsible_exp      | varchar(255) | Operations manager |
 | zone                 | varchar(255) | Name of the firewall zone |
 | dmz                  | varchar(255) | DMZ (Yes/No) |
 | wifi                 | varchar(255) | Wireless |
-| connected_subnets_id | int unsigned | Network to which this subnet belongs |
-| gateway_id           | int unsigned | Gateway |
-| vlan_id              | int unsigned | Associated VLAN |
-| network_id           | int unsigned | Associated network |
+| responsible_exp      | varchar(255) | Operations manager |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+The "connected_subnets_id" field is used to define a foreign key. However, this one does not seem to be used.
 
 #### External input gateways
 
@@ -548,6 +802,8 @@ Table *gateways* :
 | deleted_at           | timestamp    | Date of deletion |
 
 
+In the application, a subnet can be attached to a gateway from these objects.
+
 #### Connected external entities
 
 Connected external entities represent external entities connected to the network.
@@ -558,13 +814,23 @@ Table *external_connected_entities* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of entity/company |
+| type                 | varchar(255) | Connexion type                    |
 | description          | longtext     | Description of the entity/company |
-| responsible_sec      | varchar(255) | Security manager of the entity/company |
+| entity_id            | int unsigned | Reference to the connected external                       |
+| network_id           | int unsigned | Référence to theinternal neetwork connected to the entity |
 | contacts             | varchar(255) | Contacts within the entity/company|
+| src                  | varchar(255) | IP Adress(es) of entity connection                          |
+| src_desc             | varchar(255) | Description de Entity source connection                   |
+| dst                  | varchar(255) | IP Adress(es) or IP Range of the destination of the connection |
+| dst_desc             | varchar(255) | Description of the Entity connection |
+| security             | text         | Security requirements of the system                         |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
 
+Exporting the data model references subnets and documents attached to a connected external entity.  
+In the application, a subnet can be attached to a connected external entity from a connected external entity object.  
+A document can be attached to a connected external entity from a connected external entity object.
 
 #### Network switches
 
@@ -592,11 +858,17 @@ Table *routers* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the router |
+| type                 | varchar(255) | router type         |
+| ip_addresses         | text         | IP Adress(es) of the router |
 | description          | longtext     | Description of the router |
 | rules                | longtext     | Filtering rules |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+Exporting the data model references physical routers attached to a logical router.  
+In the application, a physical router can be attached to a logical router from these two objects.
 
 #### Security equipment
 
@@ -610,10 +882,25 @@ Table *security_devices* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the device |
+| type                 | varchar(255) | Eqquipement type                    |
+| attributes           | varchar(255) | Equipment attributes                |
+| icon_id              | int unsigned | Reference to a specific image            |
 | description          | longtext     | Description of the device |
+| address_ip           | varchar(255) | IP Adress(es) of the equipment          |
+| vendor               | varchar(255) | Vendor / editor for CPE search    |
+| product              | varchar(255) | Editor Product for CPE search  |
+| version              | varchar(255) | Version of a product for CPE search |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+The "vendor", "product" and "version" fields are not used at the moment and are therefore 
+missing from the app.  
+Data model export references physical security equipment and applications 
+attached to logical safety equipment.  
+In the application, physical safety equipment can be attached to safety equipment 
+logic from these two objects.  
+An application can be attached to logical security equipment from these two objects.
 
 #### DHCP servers
 
@@ -626,6 +913,7 @@ Table *dhcp_servers* :
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the DHCP server |
 | description          | longtext     | Description of the DHCP server |
+| address_ip           | varchar(255) | Adresse(s) IP of the server |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
@@ -641,6 +929,7 @@ Table *dnsservers* :
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the DNS server |
 | description          | longtext     | Description of the DNS server |
+| address_ip           | varchar(255) | Adresse(s) IP of the server |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
@@ -651,15 +940,26 @@ Clusters are a set of logical servers hosted on one or more physical servers.
 
 Table *clusters* :
 
-| Champ                | Type         | Description      |
-|:---------------------|:-------------|:-----------------|
-| id                   | int unsigned | auto_increment |
-| name                 | varchar(255) | Name of the cluster |
-| type                 | varchar(255) | Type of cluster |
-| description          | longtext     | Description of the cluster |
-| address_ip           | varchar(255) | IP address of the cluster |
+| Champ                | Type         | Description                     |
+|:---------------------|:-------------|:--------------------------------|
+| id                   | int unsigned | auto_increment                  |
+| name                 | varchar(255) | Name of the cluster             |
+| type                 | varchar(255) | Type of cluster                 |
+| icon_id              | int unsigned | Reference to a specific image   |
+| description          | longtext     | Description of the cluster      |
+| attributes           | varchar(255) | Cluster attributes              |
+| address_ip           | varchar(255) | IP address of the cluster       |
+| created_at           | timestamp    | Date of creation                |
+| updated_at           | timestamp    | Date of update                  |
+| deleted_at           | timestamp    | Date of deletionn               |
 
 
+The data model export references logical routers, logical and physical servers attached to a cluster.  
+In the application, a logical router can be attached to a cluster from a cluster object.  
+A logical server can be attached to a cluster from these two objects.  
+A physical server can be attached to a cluster from these two objects.
+
+---
 #### Logical servers
 
 Logical servers are a logical breakdown of a physical server. If the physical server is not virtualized, it is split into a single logical server.
@@ -672,6 +972,10 @@ Table *logical_servers* :
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the logical server |
 | description          | longtext     | Description of the logical server |
+| icon_id              | int unsigned | Reference to a specific image   |
+| type                 | varchar(255) | Server type (appli, DB, ...)                 |
+| active               | tinyint(1)   | Server status active (1) or obsolete (0)          |
+| attributes           | varchar(255) | Server atributes (tags)            |
 | net_services         | varchar(255) | Active network services |
 | configuration        | longtext     | Server configuration |
 | operating_system     | varchar(255) | Operative system |
@@ -680,11 +984,114 @@ Table *logical_servers* :
 | memory               | varchar(255) | Quantity of RAM |
 | environment          | varchar(255) | Environnement (prod, dev, test, ...) |
 | disk                 | int          | Storage allocated |
+| disk_used            | int          | Stroage used                           |
+| domain_id            | int unsigned | Administartion domain for this server   |
 | install_date         | datetime     | Date of server installation |
 | update_date          | datetime     | Date of server upgrade |
+| patching_frequency   | int signed   | Recurrence of update                   |
+| next_update          | date         | NNewt planned update date              |
+| databases            | List int [,] | IDs List of related database(s)        |
+| cluster_id           | List int [,] | IDs List of related cluster(s)         |
+| physical_servers     | List int [,] | IDs List of related physical_servers   |
+| applications         | List int [,] | IDs List of related applications       |
+| containers           | List int [,] | IDs List of related containers         |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+The "patching_frequency" and "next_update" fields are not used at the moment and are therefore absent from the application.  
+Exporting the reference data model: 
+
+- applications,
+- physical servers,
+- the documents,
+- databases,
+- clusters,
+- certificates,
+- and the containers
+
+attached to a logical server.  
+
+in the application, an application can be attached to a logical server from these two objects.  
+A database can be attached to a logical server from these two objects.  
+A cluster can be attached to a logical server from these two objects.  
+A physical server can be attached to a logical server from these two objects.  
+A certificate can be attached to a logical server from a certificate object.  
+A container can be attached to a logical server from a container object.
+
+The "documents" field does not appear to be used in a logical server's data model.
+
+
+
+
+#### Containers
+
+Containers are part of virtualization systems. They can operate in clusters or in isolation.
+on internal or external logical servers (cloud).
+
+Table *containers* :
+
+| Champ                | Type         | Description                                  |
+|:---------------------|:-------------|:---------------------------------------------|
+| id                   | int unsigned | auto_increment                               |
+| name                 | varchar(255) | Container name                               |
+| description          | longtext     | Container description                        |
+| type                 | varchar(255) | Type of the container (docker, kubernetes, ...) |
+| icon_id              | int unsigned | Reference to a specific image                |
+| created_at           | timestamp    | Date of creation                             |
+| updated_at           | timestamp    | Date of update                               |
+| deleted_at           | timestamp    | Date of deletion                             |
+
+Data model export references applications, databases and servers
+logics attached to a container.  
+In the application, an application can be attached to a container from these two objects.  
+A database can be attached to a container from these two objects.  
+A logical server can be attached to a container from a containing object.
+
+#### Logical flows
+
+Les flux logiques décrivent des relations au niveau des couches 3 et 4 du modèle OSI.  
+
+Table *logical_flows* :
+
+Principe général :
+
+| Champ                | Type         | Description                                   |
+|:---------------------|:-------------|:----------------------------------------------|
+| id                   | int unsigned | auto_increment                                |
+| name                 | varchar(255) | Name of logical flow                          |
+| description          | text         | Description of logical flow                   |
+| chain                | varchar(255) | INPUT / OUTPUT / FORWARD                      |
+| interface            | varchar(255) | Network interface linked                      |
+| router_id            | int unsigned | Router used for this logical flow             |
+| priority             | int signed   | Priority of the rule / flow                   |
+| action               | varchar(255) | Rule action (Grant, refuse, restrict, ...)    |
+| protocol             | varchar(255) | Protocol(s) used by this flow                 |
+| source_ip_range      | varchar(255) | Source IP range                               |
+| dest_ip_range        | varchar(255) | Destination IP range                          |
+| source_port          | varchar(255) | Logical port of the source                    |
+| dest_port            | varchar(255) | Logical port of the destination               |
+| *device*_source_id   | int unsigned | Actif source                                  |
+| *device*_dest_id     | int unsigned | Actif de destination                          |
+| users                | varchar(255) | Users concerned by this flow rule             |
+| schedule             | varchar(255) | Period of activity of the rule/flow           |
+| created_at           | timestamp    | Date of creation                              |
+| updated_at           | timestamp    | Date of update                                |
+| deleted_at           | timestamp    | Date of deletion                              |
+
+Les actifs sources et destination peuvent être :
+
+| Actif (*device*)                | Source  | Destination |
+|:--------------------------------|:-------:|:-----------:|
+| Peripherals                     | ✅      | ✅          |
+| Physical Security Equipement    | ✅      | ✅          |
+| Physical server                 | ✅      | ✅          |
+| Storage infrastructure          | ✅      | ✅          |
+| Workstations                    | ✅      | ✅          |
+| Logical security equipment      | ✅      | ✅          |
+| Logical server                  | ✅      | ✅          |
+| Subnetworks                     | ✅      | ✅          |
+
 
 #### Certificates
 
@@ -703,14 +1110,20 @@ Table *certificates* :
 | start_validity       | date         | Date start of validity |
 | end_validity         | date         | Date end of validity |
 | status               | int          | State of certificate (RFC 6960) |
+| last_notification    | datetime     | Last notification submited |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
 
 * Note:
-    * status = 0: "Good"
-    * status = 1: "Revoked
+    * status = 0 : "Good"
+    * status = 1 : "Revoked
     * status = 2 : "Unknown
+
+The "last_notification" field is not used at the moment and is therefore missing from the application.  
+Exporting the data model references logical applications and servers attached to a certificate.  
+In the application, a certificate can be attached to a logical application or server from a certificate object.
+
 
 #### VLAN
 
@@ -723,10 +1136,18 @@ Table *vlans* :
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of VLAN |
 | description          | longtext     | Description of VLAN |
+| vlan_id              | int signed   | VLAN  number     |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
 
+
+The data model export references physical routers and logical switches ("network switches")
+attached to a VLAN.
+In the application, a VLAN can be attached to a physical router from a physical router object.  
+In the application, a VLAN can be attached to a subnet or a logic switch from these two objects.
+
+---
 
 ### Physical infrastructure
 
@@ -746,6 +1167,7 @@ Table *sites* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of the site |
+| icon_id           | int unsigned | Reference to a specific image            |
 | description          | longtext     | Description of the site |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
@@ -761,13 +1183,18 @@ Table *buildings* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of building |
+| icon_id              | int unsigned | Reference to a specific image            |
+| type                 | varchar(255) | Type of Room/Building               |
+| attributes           | varchar(255) | Attributes of the building / room                        |
 | description          | longtext     | Description of the building |
 | site_id              | int unsigned | Reference to the site |
-| camera               | tinyint(1)   | The building / room is surveilled by a camera |
-| badge                | tinyint(1)   | The building / requires a badge for access |
+| building_id          | int unsigned | Reference to a building / room |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+In the application, a building /room or a site can be attached to a building /room from a building object /
+room.
 
 #### Racks
 
@@ -795,16 +1222,49 @@ Table *physical_servers* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of physical server |
+| icon_id              | int unsigned | Reference to a specific image            |
 | description          | longtext     | Description of physical server |
 | type                 | varchar(255) | Type / model of server |
+| cpu                  | varchar(255) | Number of CPU |
+| memory               | varchar(255) | Quantity of RAM |
+| disk                 | int          | Storage allocated |
+| disk_used            | int          | Stroage used                           |
+| configuration        | longtext     | Server configuration |
+| operating_system     | varchar(255) | Operative system |
+| address_ip           | varchar(255) | IP address |
+| install_date         | datetime     | Date of server installation |
+| update_date          | datetime     | Date of server upgrade |
 | responsible          | varchar(255) | Person/Team responsible for the server |
-| configuration        | longtext     | Configuration of the server |
 | site_id              | int unsigned | Reference to the site |
 | building_id          | int unsigned | Reference to the building / room |
 | bay_id               | int unsigned | Reference to the rack |
+| clusters             | List int [,] | IDs list of related cluster(s)         |
+| logical_servers      | List int [,] | IDs List of related logical(s) servers(s) |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+Data model export references applications, (logical) clusters, and servers 
+logics attached to a physical server.  
+In the application, an application can be attached to a physical server from a physical server object.  
+A cluster can be attached to a physical server from these two types of objects.  
+A logical server can be attached to a physical server from these two types of objects.
+
+For readability, fields defined in the data model but unused for the 
+moment in application for table *physical_servers* have been grouped into the following table:
+
+
+| Champ                | Type         | Description                             |
+|:---------------------|:-------------|:----------------------------------------|
+| vendor               | varchar(255) | Vendor / editor for CPE search        |
+| product              | varchar(255) | Product of an editor for CPE search   |
+| version              | varchar(255) | Version of a product for CPE search   |
+| patching_group       | varchar(255) | Group for upgrade                       |
+| patching_frequency   | varchar(255) | Frequency of upgrade                    |
+| next_update          | date         | Date of next upgrade                    |
+| physical_swicth_id   | int unsigned | ID of related Physical switch           |
+
 
 #### Workstations
 
@@ -816,13 +1276,53 @@ Table *workstations* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of workstation |
+| icon_id              | int unsigned | Reference to a specific image            |
 | description          | longtext     | Description of workstation |
+| status               | varchar(255) | Status of the workstation (lifecycle incident)   |
 | type                 | varchar(255) | Type / model of workstation |
+| entity_id            | int unsigned | ID of the related entity                   |
+| domain_id            | int unsigned | ID of the related users identification domain      |
+| user_id              | int unsigned | ID of the reference domain user of the workstation |
+| other_user           | int unsigned | Workstation users , if outside of domain               |
+| manufacturer         | varchar(255) | Workstation manufacturer                                        |
+| model                | varchar(255) | Workstation model                                               |
+| serial_number        | varchar(255) | Workstation serial number                                       |
+| cpu                  | varchar(255) | Workstation CPU                                          |
+| memory               | varchar(255) | Workstation RAM                                     |
+| disk                 | int signed   | Disk size of the workstation                           |
+| operating_system     | varchar(255) | Workstation Operating system                                  |
+| network_id           | int unsigned | ID of the workstation related network               |
+| address_ip           | varchar(255) | IP Adresse(s) of the workstation                       |
+| mac_address          | varchar(255) | MAC Adresse(s) MAC of the workstation                           |
+| network_port_type    | varchar(255) | Network Connector type (RJ45, USB, SFP,...)              |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+Exporting the data model references applications attached to a workstation.  
+In the application, an application can be attached to a workstation from a workstation object.
+
+For readability reasons, fields defined in the data model but unused at the moment 
+in the application for the table *workstations* have been grouped in the following table:
+
+| Champ                | Type         | Description                             |
+|:---------------------|:-------------|:----------------------------------------|
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
+| warranty             | varchar(255) | Guarantee contract                      |
+| warranty_start_date  | date         | Guarantee start date                    |
+| warranty_end_date    | date         | Guaranty end date                       |
+| warranty_period      | date         | Guarantee period                        |
+| purchase_date        | date         | Purchase date                           |
+| fin_value            | decimal      | Financial value.                        | 
+| last_inventory_date  | date         | Date of last inventory                  |
+| update_source        | varchar(255) | Source of inventory update              |
+| agent_version        | varchar(255) | Inventory agent verrsion                |
+| physical_swicth_id   | int unsigned | ID related to the physical switch       |
+
 
 
 #### Storage infrastructures
@@ -838,9 +1338,17 @@ Table *storage_devices* :
 | description          | longtext     | Description of the storage infrastructure |
 | site_id              | int unsigned | Reference to the site |
 | building_id          | int unsigned | Reference to building / room |
+| bay_id               | int unsigned | Reference to the rack |
+| address_ip           | varchar(255) | IP address of storage infrastructure |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+The "vendor", "product" and "version" fields are not used at the moment and are therefore missing from the application.
 
 #### Peripherals
 
@@ -854,12 +1362,24 @@ Table *peripherals* :
 | name                 | varchar(255) | Name of peripheral |
 | description          | longtext     | Description of peripheral |
 | type                 | varchar(255) | Type / model of peripheral |
+| icon_id              | int unsigned | Reference to a specific image            |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
 | bay_id               | int unsigned | Reference to rack |
+| responsible          | varchar(255) | Internal responsible of this equipment  |
+| address_ip           | varchar(255) | IP Adress of the equipment                         |
+| domain               | varchar(255) | General domain where it fits to (IT, OT, IOT, etc.) |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
+| provider_id          | int unsigned | ID related to the provider of this peripheral      |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+Data model export references applications using a device.  
+In the application, a device can be attached to an application from a peripheral object.
+
 
 #### Phones
 
@@ -871,11 +1391,21 @@ Fixed and mobile phones belonging to the organization.
 | name                 | varchar(255) | Name of telephone |
 | description          | longtext     | Description of telephone |
 | type                 | varchar(255) | Type / model of telephone |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
+| physical_switch_id   | int unsigned | ID related to the physical switch  |
+| address_ip           | varchar(255) | IP Adress of the phone               |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+The "vendor", "product" and "version" fields are not used at the moment and are therefore missing from the application.
+
+
 
 #### Physical switches
 
@@ -891,9 +1421,21 @@ Table *physical_switches* :
 | type                 | varchar(255) | Type / model of physical switch |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
+| bay_id               | int unsigned | Reference to rack |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+The "vendor", "product" and "version" fields are not used at the moment and are therefore missing from the application.
+
+'data model export references logical switches attached to a physical switch.  
+In the application, a physical switch can be attached to a logical switch (denoted as "Network Switches")
+from these two types of objects.
+
 
 #### Physical routers
 
@@ -909,9 +1451,19 @@ Table *physical_routers* :
 | type                 | varchar(255) | Type / model of physical router |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
+| bay_id               | int unsigned | Reference to rack |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+The "vendor", "product" and "version" fields are not used at the moment and are therefore missing from the application.
+
+Exporting the data model references logical routers and VLANs attached to a physical router.  
+In the application, a physical router can be attached to a logical router (denoted as "Routers" from these two types of objects.  
+A VLAN can be attached to a physical router from a physical router object.
 
 #### WiFi terminals
 
@@ -927,6 +1479,11 @@ Table *wifi_terminals* :
 | type                 | varchar(255) | Type / model of WiFi hotspot |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
+| address_ip           | varchar(255) | IP Adress of the wifi terminal          |
+| vendor               | varchar(255) | Vendor / editor for CPE search          |
+| product              | varchar(255) | Product of an editor for CPE search     |
+| version              | varchar(255) | Version of a product for CPE search     |
+| created_at           | timestamp    | Date of creation |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
@@ -943,13 +1500,58 @@ Table *physical_security_devices* :
 |:---------------------|:-------------|:-----------------|
 | id                   | int unsigned | auto_increment |
 | name                 | varchar(255) | Name of security equipment |
+| icon_id              | int unsigned | Reference to a specific image            |
 | description          | longtext     | Description of security equipment  |
 | type                 | varchar(255) | Type / model of security equipment  |
 | site_id              | int unsigned | Reference to site |
 | building_id          | int unsigned | Reference to building / room |
+| bay_id               | int unsigned | Reference to rack |
+| address_ip           | varchar(255) | IP Adress        |
 | created_at           | timestamp    | Date of creation |
 | updated_at           | timestamp    | Date of update |
 | deleted_at           | timestamp    | Date of deletion |
+
+
+
+#### Physical links
+
+Physical links represent the cables between physical or logical objects.  
+Logical objects can have physical links, for example within a virtualized network.  
+A physical link is different from a logical flow. A physical link describes a relationship at layers 1 or 2 of the OSI model.  
+A logic flow describes a relationship at layers 3 and 4 of the OSI model.
+
+Table *physical_links* :
+
+| Champ           | Type         | Description                             |
+|:----------------|:-------------|:----------------------------------------|
+| id              | int unsigned | auto_increment                          |
+| *device*_src_id | int unsigned | Source                                  |
+| src_id          | varchar(255) | Physical port of the source             |
+| *device*_dst_id | int unsigned | Destination                             |
+| dst_port        | varchar(255) | Physical port of the destination        |
+| created_at      | timestamp    | Date of creation                        |
+| updated_at      | timestamp    | Date of update                          |
+| deleted_at      | timestamp    | Date of deletion                      |
+
+Les ***devices***** sources or destination might be :
+
+| Actif                            | Source  | Destination |
+|:---------------------------------|:-------:|:-----------:|
+| Périphérique                     | ✅      | ✅          |
+| Téléphone                        | ✅      | ✅          |
+| Routeur physique                 | ✅      | ✅          |
+| Equipement de sécurité physique  | ✅      | ✅          |
+| Serveur physique                 | ✅      | ✅          |
+| Commutateur physique             | ✅      | ✅          |
+| Infrastructure de stockage       | ✅      | ✅          |
+| Borne Wifi                       | ✅      | ✅          |
+| Poste de travail                 | ✅      | ✅          |
+| Serveur logique                  | ✅      | ✅          |
+| Commutateur logique              | ✅      | ✅          |
+| Routeur logique                  | ✅      | ✅          |
+
+
+
 
 #### WAN
 


### PR DESCRIPTION
La version française de dev était bien avancée et enrichie ! 
Sur la version anglaise, j'ai essayé d'aligner avec la version française

Petit changement 
- Dans la table processes , remplacement de identifier par name

- **Impact** étant dans **activities**, j'ai mis un titre 5 ##### au lieu de 4 ####
- **Evènements majeurs**  j'ai mis un titre 5 ##### au lieu de 4 ####
A vous de voir.

- Dans **applications** retrait de entity_resp_id

Je n'ai pas du tout touché à **Administration**

**subnetworks**:
connected_subnets_id remplacé par subnetwork_id (doublon)

Dans **external_connected_entities**:
Il y avait ça en anglais, qui n'existe plus en français:
| responsible_sec      | varchar(255) | Security manager of the entity/company |
Retiré

Dans **Buildings** il y avait ça en anglais:  laissé ici pour info
| camera               | tinyint(1)   | The building / room is surveilled by a camera |
| badge                | tinyint(1)   | The building / requires a badge for access |
absents en français, retiré en anglais, car pas vu dans l'interface

Remarques additionnelles:
- Petite erreur de frappe sur le site dans activities - >New: (en français)
_Biland_ d'impact sur l'activité (BIA) (bilan avec un d)

- Il n'y a pas de champs environnement dans **physical__servers**, ça pourrait etre utile..
- Je n'ai pas vu d'icon_id pour les **storage devices**..

- Je n’ai pas vu de champs provider pour **peripherals**

- Est-ce que les champs vendor, product et version sont utilisés dans peripherals?  (pas de note )

Voila, j'ai fait ce que j'ai pu..