### PR TITLE
migrate schema to Passport 13

### DIFF
--- a/database/schema/mariadb-schema.sql
+++ b/database/schema/mariadb-schema.sql
@@ -1460,7 +1460,7 @@ DROP TABLE IF EXISTS `oauth_clients`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oauth_clients` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `id` varchar(36) NOT NULL,
   `user_id` bigint(20) unsigned DEFAULT NULL,
   `name` varchar(255) NOT NULL,
   `secret` varchar(100) DEFAULT NULL,

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1425,7 +1425,7 @@ DROP TABLE IF EXISTS `oauth_clients`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oauth_clients` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `id` varchar(36) NOT NULL,
   `user_id` bigint(20) unsigned DEFAULT NULL,
   `name` varchar(255) NOT NULL,
   `secret` varchar(100) DEFAULT NULL,

--- a/database/schema/pgsql-schema.sql
+++ b/database/schema/pgsql-schema.sql
@@ -2138,7 +2138,7 @@ CREATE TABLE public.oauth_auth_codes (
 --
 
 CREATE TABLE public.oauth_clients (
-    id bigint NOT NULL,
+    id character varying(36) NOT NULL,
     user_id bigint,
     name character varying(255) NOT NULL,
     secret character varying(100),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to change OAuth client identifier format from auto-incremented numeric IDs to string-based identifiers across MariaDB, MySQL, and PostgreSQL databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->