### PR TITLE
feat: ajout du filtrage par attribut dans le menu exploration (Applications)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -350,7 +350,8 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['web.prote
 
     Route::get('/reports/explore/data', [Admin\ExplorerController::class, 'getGraphData'])
         ->name('reports.explore.data');
-
+    Route::get('/reports/explore/attributes', [Admin\ExplorerController::class, 'getAttributes'])
+        ->name('reports.explore.attributes');
 
     // Maturity levels
     Route::get('report/maturity1', [Admin\HomeController::class, 'maturity1'])->name('report.maturity1');


### PR DESCRIPTION
## Contexte

En travaillant sur une mission de cartographie applicative avec Mercator,
j'ai eu besoin de filtrer le graphe de l'explorateur selon les attributs
déclarés sur les applications (ex: Projet, Old, Prod, Appli-critique,
ou tout autre attribut libre défini par l'organisation).

Le champ `attributes` existe déjà sur `m_applications` mais n'était pas
exploité dans l'explorateur.

## Ce que j'ai "implémenté"

### `app/Http/Controllers/Admin/ExplorerController.php`

- Nouvel endpoint public `getAttributes()` qui récupère les attributs depuis
  `m_applications`, les éclate par virgule, déduplique et trie
- `buildApplications()` : ajout de `attributes` dans le `->select()`
  et transmission via `addNode()`
- `addNode()` : ajout du paramètre `?string $attributes = null`
  et du champ `'attributes' => $attributes` dans `$this->nodes[]`

### `routes/web.php`

- Ajout de `GET /reports/explore/attributes` dans le groupe `admin.`

### `resources/views/admin/reports/explore.blade.php`

- `buildNodesMap()` : ajout de `attributes: node.attributes || null`
- Nouveau select2 `#attr-filter` dans les contrôles
- `loadAttributes()` : fetch AJAX sur l'endpoint au chargement de la page
- `getAttrFilter()` : retourne les attributs sélectionnés
- `apply_filter()` : réécriture pour filtrer par attribut en plus du filtre par vue
- `deployFromNode()` : ajout de `matchAttr` pour ne déployer que les nœuds
  qui correspondent à l'attribut sélectionné
- Listeners `select2:select` et `select2:unselect` sur `#attr-filter`

## Note

A terme ce filtre pourrait être étendu aux autres objets qui ont un champ
`attributes` : `logical_servers`, `clusters`, `entities`, `buildings`,
`physical_security_devices`, `relations`, `security_devices`, `fluxes` —
avec un seul select qui agrège tous les attributs de toutes ces tables.