### PR TITLE
 Mise à jour de la docs et du mkdocs.yml avec liens fra/en dans chaqu…

### DIFF
--- a/docs/admin.fr.md
+++ b/docs/admin.fr.md
@@ -1,4 +1,6 @@
-## Administration
+# Administration
+
+🇬🇧 [Read in English](/mercator/admin)
 
 ### Gestion des utilisateurs
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,4 +1,6 @@
-## Administration
+# Administration
+
+🇫🇷 [Lire en français](/mercator/fr/admin)
 
 ### User management
 

--- a/docs/api.fr.md
+++ b/docs/api.fr.md
@@ -1,4 +1,6 @@
-## API
+# API
+
+🇬🇧 [Read in English](/mercator/api)
 
 La cartographie peut être modifiée ou mise à jour via une REST API.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,6 @@
-## API
+# API
+
+🇫🇷 [Lire en français](/mercator/fr/api)
 
 Cartography can be modified or updated via a REST API.
 

--- a/docs/apifilters.fr.md
+++ b/docs/apifilters.fr.md
@@ -1,4 +1,6 @@
-## API avancée (filtres)
+# API avancées (filtres)
+
+🇬🇧 [Read in English](/mercator/apifilters)
 
 Ce chapitre vient en complément du chapitre [API](./api.fr.md).
 

--- a/docs/apifilters.md
+++ b/docs/apifilters.md
@@ -1,4 +1,6 @@
-## API Advanced (filters)
+# API Advanced (filters)
+
+🇫🇷 [Lire en français](/mercator/fr/apifilters)
 
 This part is an addition of the API chapter [API](./api.md).
 

--- a/docs/application.fr.md
+++ b/docs/application.fr.md
@@ -1,4 +1,7 @@
-## Application
+# Application
+
+🇬🇧 [Read in English](/mercator/application)
+
 
 [<img src="/mercator/fr/images/homepage.png" width="600">](images/homepage.fr.png)
 

--- a/docs/application.md
+++ b/docs/application.md
@@ -1,4 +1,6 @@
-## Application
+# Application
+
+🇫🇷 [Lire en français](/mercator/fr/application)
 
 [![homepage.png](images/homepage.png)](images/homepage.png)
 

--- a/docs/bpmn.fr.md
+++ b/docs/bpmn.fr.md
@@ -1,5 +1,7 @@
 # Module BPMN 2.0
 
+🇬🇧 [Read in English](/mercator/bpmn)
+
 ## Introduction
 
 Le module BPMN (Business Process Model and Notation) disponible dans la version Enterprise de Mercator

--- a/docs/bpmn.md
+++ b/docs/bpmn.md
@@ -1,5 +1,7 @@
 # BPMN 2.0 Module
 
+🇫🇷 [Lire en français](/mercator/fr/bpmn)
+
 ## Introduction
 
 The BPMN (Business Process Model and Notation) module, available in the Enterprise version of Mercator, allows you to

--- a/docs/cartography.fr.md
+++ b/docs/cartography.fr.md
@@ -1,4 +1,6 @@
-## Vues
+# Cartographie / Vues
+
+🇬🇧 [Read in English](/mercator/cartography)
 
 La cartographie est composée de trois vues allant progressivement du métier vers la technique, elles-mêmes déclinées en
 vues :

--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -1,4 +1,6 @@
-## Views
+# Views /Cartograpgy
+
+🇫🇷 [Lire en français](/mercator/fr/cartography)
 
 The cartography is made up of three views progressively moving from business to technical, themselves broken down into
 views:

--- a/docs/config.fr.md
+++ b/docs/config.fr.md
@@ -1,4 +1,6 @@
-# **Guide de Configuration de Mercator**
+# Guide de Configuration de Mercator
+
+🇬🇧 [Read in English](/mercator/config)
 
 Ce document décrit l’ensemble des options de configuration disponibles dans Mercator, notamment l’intégration LDAP, la
 prise en charge des groupes imbriqués pour Active Directory, la configuration du mail, le cache et les fonctionnalités

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,6 @@
-# **Mercator Configuration Guide**
+# Mercator Configuration Guide
+
+🇫🇷 [Lire en français](/mercator/fr/config)
 
 This document describes all configuration options available in Mercator, including LDAP integration, Active Directory
 nested group support, mail settings, caching, and optional features.

--- a/docs/exploration.fr.md
+++ b/docs/exploration.fr.md
@@ -1,4 +1,6 @@
-## Fonctionnalité Exploration
+# Fonctionnalité Exploration
+
+🇬🇧 [Read in English](/mercator/exploration)
 
 L'outil **Exploration** (`Outils → Exploration`) permet de naviguer dynamiquement dans le graphe de relations entre les
 assets. Il révèle les dépendances entre couches : vers le **haut** (abstrait / métier) ou vers le **bas** (concret /

--- a/docs/exploration.md
+++ b/docs/exploration.md
@@ -1,4 +1,6 @@
-## Exploration Feature
+# Exploration Feature
+
+🇫🇷 [Lire en français](/mercator/fr/exploration)
 
 The **Exploration** tool (`Tools → Exploration`) allows you to dynamically navigate through the asset relationship
 graph. It reveals dependencies between layers: upward (abstract / business) or downward (concrete / physical).

--- a/docs/import.fr.md
+++ b/docs/import.fr.md
@@ -1,4 +1,6 @@
-## Interface Import / Export de Données
+# Interface Import / Export de Données
+
+🇬🇧 [Read in English](/mercator/import)
 
 Cette interface permet d’**importer** et d’**exporter** des données de la cartographie du système d'information via des
 feuilles de calcul.

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,4 +1,6 @@
-## Data Import/Export Interface
+# Data Import/Export Interface
+
+🇫🇷 [Lire en français](/mercator/fr/import)
 
 This interface allows you to import and export information system mapping data via Excel files.
 

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -1,6 +1,6 @@
-🇫🇷 [Lire en français](/mercator/fr/) &nbsp;|&nbsp; 🇬🇧 [Read in English](/mercator)
+# Introduction
 
-## Introduction
+🇬🇧 [Read in English](/mercator)
 
 Mercator est une application Web permettant de gérer la cartographie d’un système d’information comme
 décrit dans

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-🇫🇷 [Lire en français](/mercator/fr/) &nbsp;|&nbsp; 🇬🇧 [Read in English](/mercator)
+# Introduction
 
-## Introduction
+🇫🇷 [Lire en français](/mercator/fr/)
 
 Mercator is a Web application for managing the mapping of an information system as described in the
 [Mapping the Information System Guide](https://messervices.cyber.gouv.fr/guides/en-mapping-information-system)

--- a/docs/maturity.fr.md
+++ b/docs/maturity.fr.md
@@ -1,4 +1,6 @@
-## Niveaux de maturité
+# Niveaux de maturité
+
+🇬🇧 [Read in English](/mercator/maturity)
 
 Les niveaux de maturité représentent le pourcentage d'exhaustivité de la cartographie. C'est un indicateur de l'effort
 restant à fournir pour atteindre une cartographie complète, conformément aux recommandations

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -1,4 +1,6 @@
-## Maturity Levels
+# Maturity Levels
+
+🇫🇷 [Lire en français](/mercator/fr/maturity)
 
 Maturity levels represent the completeness percentage of the cartography. It is an indicator of the remaining effort
 required to achieve a complete mapping, in accordance with the recommendations of the

--- a/docs/model.fr.md
+++ b/docs/model.fr.md
@@ -1,4 +1,6 @@
-## Modèle de données
+# Modèle de données
+
+🇬🇧 [Read in English](/mercator/model)
 
 [<img src="/mercator/fr/images/model.png" width="700">](images/model.fr.png)
 
@@ -995,6 +997,7 @@ Les commutateurs réseau sont les composants gérant les connexions entre les di
 | name        | varchar(255) | Nom du commutateur         |
 | description | longtext     | Description du commutateur |
 | ip          | varchar(255) | Adresse IP du commutateur  |
+| physical_switches | List int [,] | Liste des IDs des switches physiques liés |
 | created_at  | timestamp    | Date de création           |
 | updated_at  | timestamp    | Date de mise à jour        |
 | deleted_at  | timestamp    | Date de suppression        |
@@ -1515,6 +1518,12 @@ dans l'application pour la table *workstations* ont été regroupés dans le tab
 | physical_swicth_id  | int unsigned | Référence vers le commutateur physique  |
 
 #### Infrastructures de stockage
+```markdown
+***NOTE***: Les infrastructures de stockage sont conservées pour la rétrocompatibilité, mais cette table n'est pas maintenue.
+ On peut remplacer cet asset par:
+- Un serveur logique
+- Un serveur physique 
+```
 
 Les infrastructures de stockage sont des supports physiques ou réseaux de stockage de données : serveur de stockage en
 réseau (NAS), réseau de stockage (SAN), disque dur…

--- a/docs/model.md
+++ b/docs/model.md
@@ -1,4 +1,6 @@
-## Data model
+# Data model
+
+🇫🇷 [Lire en français](/mercator/fr/model)
 
 [<img src="/mercator/images/model.png" width="700">](images/model.png)
 
@@ -1035,6 +1037,7 @@ Network switches are the components that manage connections between the various 
 | name        | varchar(255) | Name of the switch        |
 | description | longtext     | Description of the switch |
 | ip          | varchar(255) | IP address of the switch  |
+| physical_switches | List int [,] | IDs List of Physical switched attached |
 | created_at  | timestamp    | Date of creation          |
 | updated_at  | timestamp    | Date of update            |
 | deleted_at  | timestamp    | Date of deletion          |
@@ -1565,6 +1568,13 @@ been gathered in the following table:
 The "vendor", "product" and "version" fields are not used and therefore are absent of the app.
 
 #### Storage infrastructures
+
+```markdown
+ ***NOTE***: This storage infrastructures table is kept for legacy compatibility, but it is not maintained anymore.
+ You can replace this asset by :
+- A Logical Server
+- A Physical Server
+```
 
 Storage infrastructures are physical media or data storage networks: network attached storage (NAS), storage area
 network (SAN), hard disk...

--- a/docs/references.fr.md
+++ b/docs/references.fr.md
@@ -1,4 +1,6 @@
-## Références
+# Références
+
+🇬🇧 [Read in English](/mercator/references)
 
 Les références utilisées dans cette documentation sont :
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,4 +1,6 @@
-## References
+# References
+
+🇫🇷 [Lire en français](/mercator/fr/references)
 
 The references used in this documentation are :
 

--- a/docs/reports.fr.md
+++ b/docs/reports.fr.md
@@ -1,4 +1,6 @@
-## Rapports
+# Rapports
+
+🇬🇧 [Read in English](/mercator/reports)
 
 ### Rapport de cartographie
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,4 +1,6 @@
-## Reports
+# Reports
+
+🇫🇷 [Lire en français](/mercator/fr/reports)
 
 ### Mapping report
 

--- a/docs/usecases.fr.md
+++ b/docs/usecases.fr.md
@@ -1,4 +1,6 @@
-## Cas d'utilisation
+# Cas d'usage
+
+🇬🇧 [Read in English](/mercator/usecases)
 
 Mercator permet d'aider à la mise en place d'un grand nombre de mesures de sécurité recommandées par la norme ISO 27002.
 En suivant les cas d'utilisation décrits ci-dessous, vous pouvez mettre en place un processus de cartographie des

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -1,4 +1,6 @@
-## Use cases
+# Use cases
+
+🇫🇷 [Lire en français](/mercator/fr/usecases)
 
 Mercator can help you implement many of the security measures recommended by ISO 27002. By following the use cases
 described below, you can put in place a robust and effective information systems mapping process that can assist you in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,63 +20,80 @@ plugins:
   - search
   - i18n:
       docs_structure: suffix
+      fallback_to_default: true
       languages:
         - locale: en
           default: true
           name: English
           build: true
-          nav_translations:
-            Introduction: "Introduction"
-            Mapping: "Mapping"
-            Maturity: "Maturity"
-            Application: "Application"
-            BPMN 2.0: "BPMN 2.0"
-            Reports: "Reports"
-            Use cases: "Use cases"
-            Data model: "Data model"
-            Exploration: "Exploration"
-            Administration: "Administration"
-            Configuration: "Configuration"
-            Import: "Import"
-            API: "API"
-            API advanced (filters): "API advanced (filters)"
-            References: "References"
+          # nav_translations:
+          #   Introduction: "Introduction"
+          #   Mapping: "Mapping"
+          #   Maturity: "Maturity"
+          #   Application: "Application"
+          #   BPMN 2.0: "BPMN 2.0"
+          #   Reports: "Reports"
+          #   Use cases: "Use cases"
+          #   Data model: "Data model"
+          #   Exploration: "Exploration"
+          #   Administration: "Administration"
+          #   Configuration: "Configuration"
+          #   Import: "Import"
+          #   API: "API"
+          #   API advanced (filters): "API advanced (filters)"
+          #   References: "References"
         - locale: fr
           name: Français
           build: true
-          nav_translations:
-            Introduction: "Introduction"
-            Mapping: "Cartographie"
-            Maturity: "Maturité"
-            Application: "Application"
-            BPMN 2.0: "BPMN 2.0"
-            Reports: "Rapports"
-            Use cases: "Cas d'usage"
-            Data model: "Modèle de données"
-            Exploration: "Exploration"
-            Administration: "Administration"
-            Configuration: "Configuration"
-            Import: "Import"
-            API: "API"
-            API advanced (filters): "API avancée (filtres)"
-            References: "Références"
+          # nav_translations:
+          #   Introduction: "Introduction"
+          #   Mapping: "Cartographie"
+          #   Maturity: "Maturité"
+          #   Application: "Application"
+          #   BPMN 2.0: "BPMN 2.0"
+          #   Reports: "Rapports"
+          #   Use cases: "Cas d'usage"
+          #   Data model: "Modèle de données"
+          #   Exploration: "Exploration"
+          #   Administration: "Administration"
+          #   Configuration: "Configuration"
+          #   Import: "Import"
+          #   API: "API"
+          #   API advanced (filters): "API avancée (filtres)"
+          #   References: "Références"
 
 nav:
-  - Introduction: index.md
-  - Mapping: cartography.md
-  - Application: application.md
-  - Maturity: maturity.md
-  - BPMN 2.0: bpmn.md
-  - Reports: reports.md
-  - Use cases: usecases.md
-  - Data model: model.md
-  - Exploration: exploration.md
-  - Administration: admin.md
-  - Configuration: config.md
-  - Import: import.md
-  - API: api.md
-  - API advanced (filters): apifilters.md
-  - References: references.md
+  - index.md
+  - cartography.md
+  - application.md
+  - maturity.md
+  - bpmn.md
+  - reports.md
+  - exploration.md
+  - usecases.md
+  - model.md
+  - admin.md
+  - config.md
+  - import.md
+  - api.md
+  - apifilters.md
+  - references.md
+# nav:
+#   - Introduction: index.md
+#   - Mapping: cartography.md
+#   - Application: application.md
+#   - Maturity: maturity.md
+#   - BPMN 2.0: bpmn.md
+#   - Reports: reports.md
+#   - Use cases: usecases.md
+#   - Data model: model.md
+#   - Exploration: exploration.md
+#   - Administration: admin.md
+#   - Configuration: config.md
+#   - Import: import.md
+#   - API: api.md
+#   - API advanced (filters): apifilters.md
+#   - References: references.md
 
 extra:
   alternate:


### PR DESCRIPTION
Bonjour,
Mise à jour du fichier mkdocs.yml pour supporter le nouveau i18n
- Les titres des pages sont pris dans la première ligne des fichiers markdown, si et seulement si le titre est de niveau 1 (#)
- Ajout d'un lien sur la langue fra pour le s page sanglaises et vice versa.
Note : le lien est sous le titre # sinon, les pages perdent leur noms dasn mkdocs.
- AJout du champs | physical_switches | List int [,] | Liste des IDs des switches physiques liés | dans network-switches
- Ajout d'un note d'obsolescence dans storage-infrastructure
