### PR TITLE
Correction doc model dans administration

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -1,6 +1,4 @@
-# Data model
-
-🇫🇷 [Lire en français](/mercator/fr/model)
+## Data model
 
 [<img src="/mercator/images/model.png" width="700">](images/model.png)
 
@@ -731,10 +729,12 @@ The  ***device***_ for source_id or dest_id can be: :
 
 In the app, an information can be linked with an application flow from an application flow object.
 
-#### Administration areas
+### Administration areas
 
 *Nota*: OVI is coming from the French military programme law. The closest equivalents in EU regulations are OES
 (Operators of Essential Services, EU 2016/1148, NIS) and EE (Essential Entities, EU 2022/2555, NIS 2).
+
+[<img src="/mercator/images/administration.png" width="400">](images/administration.png)
 
 #### Administration area
 
@@ -801,7 +801,10 @@ These objects represent an organized grouping of Active Directory domains or LDA
 Active Directory domains / LDAP are company IT directories. They contains user and computer accounts, contacts,
 objects rights, and a part of IT policies (e.g. Group Policy Object - GPO).
 
-Table *domaines_ads* :
+| Table                                            | api                 |
+|:-------------------------------------------------|:--------------------|
+| <span style="color: blue;">*domaines_ads*</span> | `/api/domaines-ads` |
+
 
 | Champ                  | Type         | Description                             |
 |:-----------------------|:-------------|:----------------------------------------|
@@ -825,7 +828,9 @@ A logical server can be linked with an AD domain / LDAP from these two objects.
 
 Users are user accounts with privileged rights on IT systems.
 
-Table *admin_users* :
+| Table                                           | api                |
+|:------------------------------------------------|:-------------------|
+| <span style="color: blue;">*admin_users*</span> | `/api/admin-users` |
 
 | Champ       | Type         | Description                  |
 |:------------|:-------------|:-----------------------------|
@@ -1037,7 +1042,6 @@ Network switches are the components that manage connections between the various 
 | name        | varchar(255) | Name of the switch        |
 | description | longtext     | Description of the switch |
 | ip          | varchar(255) | IP address of the switch  |
-| physical_switches | List int [,] | IDs List of Physical switched attached |
 | created_at  | timestamp    | Date of creation          |
 | updated_at  | timestamp    | Date of update            |
 | deleted_at  | timestamp    | Date of deletion          |
@@ -1568,13 +1572,6 @@ been gathered in the following table:
 The "vendor", "product" and "version" fields are not used and therefore are absent of the app.
 
 #### Storage infrastructures
-
-```markdown
- ***NOTE***: This storage infrastructures table is kept for legacy compatibility, but it is not maintained anymore.
- You can replace this asset by :
-- A Logical Server
-- A Physical Server
-```
 
 Storage infrastructures are physical media or data storage networks: network attached storage (NAS), storage area
 network (SAN), hard disk...


### PR DESCRIPTION
Bonjour,

Petite corrections sur l'alignement français et anglais.
- Le menu administration était en titre 4 et pas 3, donc pas visible dans le menu au bon endroit.
- Ajout des apis pour deux objets dans administration qui étaient restés comme la version précédente.

Merci
Olivier
