### PR TITLE
add mysql SSL_VERIFY_SERVER_CERT parameter

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,9 +59,11 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('MYSQL_ATTR_SSL_VERIFY_SERVER_CERT', true),
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            ], static fn ($value) => $value !== null && $value !== '',
+                ARRAY_FILTER_USE_BOTH
+            ) : [],
         ],
 
         'pgsql' => [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable/disable SSL server certificate verification for MySQL database connections.
  * This setting is configurable via environment configuration and coexists with existing CA handling.
  * Applies only to MySQL connections when the MySQL driver is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->