### PR TITLE
add security device icons

### DIFF
--- a/resources/views/admin/reports/logical_infrastructure.blade.php
+++ b/resources/views/admin/reports/logical_infrastructure.blade.php
@@ -779,7 +779,7 @@ digraph  {
 
 @can('security_device_access')
     @foreach($securityDevices as $securityDevice)
-        SECURITY{{ $securityDevice->id }} [label="{{ $securityDevice->name }} {{ Session::get('show_ip') ? chr(13) . $securityDevice->address_ip : '' }}" shape=none labelloc="b"  width=1 height={{ Session::get('show_ip') && ($securityDevice->address_ip!=null) ? '1.5' :'1.1' }} image="{{ $peripheral->icon_id === null ? '/images/securitydevice.png' : route('admin.documents.show', $securityDevice->icon_id) }}" href="#{{$securityDevice->getUID()}}"]
+        SECURITY{{ $securityDevice->id }} [label="{{ $securityDevice->name }} {{ Session::get('show_ip') ? chr(13) . $securityDevice->address_ip : '' }}" shape=none labelloc="b"  width=1 height={{ Session::get('show_ip') && ($securityDevice->address_ip!=null) ? '1.5' :'1.1' }} image="{{ $securityDevice->icon_id === null ? '/images/securitydevice.png' : route('admin.documents.show', $securityDevice->icon_id) }}" href="#{{$securityDevice->getUID()}}"]
         @foreach(explode(',',$securityDevice->address_ip) as $address)
             @foreach($subnetworks as $subnetwork)
                 @if ($subnetwork->contains($address))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logical infrastructure reports now show custom icons for security devices when available; if a device has no custom icon configured, the report falls back to the default security device icon. This improves visual clarity in generated diagrams by including appropriate device visuals where provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->