### PR TITLE
Mise à jour doc model.fr et model pour information

### DIFF
--- a/docs/model.fr.md
+++ b/docs/model.fr.md
@@ -407,6 +407,8 @@ Dans l'application, une opération peut être rattachée à un acteur depuis l'o
 #### Information
 
 Une information est une donnée faisant l’objet d’un traitement informatique.
+Une information peut etre héritée d'une autre information.
+Une information peut etre liée à plusieurs informations.
 
 | Table                                           | api                |
 |:------------------------------------------------|:-------------------|
@@ -428,6 +430,9 @@ Une information est une donnée faisant l’objet d’un traitement informatique
 | security_need_auth | int          | Authenticité                          |
 | constraints        | longtext     | Contraintes légales et réglementaires |
 | retention          | varchar(255) | Durée de rétention de l'information   |
+| parents            | List int [,] | Liste d'id des informations parentes liées |
+| children           | List int [,] | Liste d'id des informations enfants liés |
+| processes          | List int [,] | Liste d'id des processus utilisant cette information | 
 | created_at         | timestamp    | Date de création                      |
 | updated_at         | timestamp    | Date de mise à jour                   |
 | deleted_at         | timestamp    | Date de suppression                   |
@@ -441,6 +446,8 @@ Il s'active depuis le menu Configuration > Paramètres.
 L'export du modèle de données référence les bases de données et processus rattachés à une information.  
 Dans l'application, une base de donnée peut être rattachée à une information depuis l'objet base de données.  
 Un processus peut être rattachée à une information depuis ces deux objets.
+
+*Note: le lien processes est une représentation du résultat généré par le endpoint [processes](#processus) et son champ **informations***
 
 ---
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -409,6 +409,8 @@ In the app, an operation can be linked with an actor from the object "operation"
 #### Information
 
 Information is data processed by a computer.
+Information can be inherited from another information.
+Information can be linked to multiple information.
 
 | Table                                           | api                |
 |:------------------------------------------------|:-------------------|
@@ -430,6 +432,9 @@ Information is data processed by a computer.
 | security_need_auth | int          | Authenticity                     |
 | constraints        | longtext     | Legal and regulatory constraints |
 | retention          | varchar(255) | Information retention period     |
+| parents            | List int [,] | IDs list of linked parents information |
+| children           | List int [,] | IDs list of linked children information |
+| processes          | List int [,] | IDs list of used processes by this information |
 | created_at         | timestamp    | Date of creation                 |
 | updated_at         | timestamp    | Date of update                   |
 | deleted_at         | timestamp    | Date of deletion                 |
@@ -444,6 +449,8 @@ The data model export lists databases and processes linked with information.
 
 In the app, a database can be linked with an information from the object "database".  
 A process can be linked to an information from these two objects.
+
+*Note: The link to processes is a view of the result generated through the endpoint [processes](#processes) and its field **informations***
 
 ---
 


### PR DESCRIPTION
Bonjour,
Ajout des champs parents , children et processes dans la doc du modèle de donnée fr et en.
basé sur le ticket : [#2013](https://github.com/dbarzin/mercator/issues/2013)

Merci
Olivier