### PR TITLE
fix typo in show role

### DIFF
--- a/resources/views/admin/roles/show.blade.php
+++ b/resources/views/admin/roles/show.blade.php
@@ -2591,7 +2591,7 @@
                 <div class="col-md-2">
                     <div class="form-group">
                         <label>{{ trans('cruds.configuration.documents.title') }}</label>
-                        @php($permission = $permissions_sorted['documento'])
+                        @php($permission = $permissions_sorted['document'])
                         <div class="form-switch">
                             <input class="form-check-input" type="checkbox" disabled name="permissions[]"
                                    data-check="{{ $permission['name'] }}" id="perm_{{ $permission['actions'][4][0] }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a permissions reference issue in the admin roles interface affecting the configuration documents section permissions display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->