### PR TITLE
doc: ajout api/documents dans datamodel et api

### DIFF
--- a/docs/api.fr.md
+++ b/docs/api.fr.md
@@ -25,17 +25,17 @@ La liste des API se trouve dans le fichier /route/api.php
 
 *Note:* Pour visualiser le datamodel d'une API, cliquer sur son nom.
 
-__Vue du RGPD__
+#### Les points de terminaison du RGPD
 
 - [/api/data-processings](./model.fr.md#registre)
 - [/api/security-controls](./model.fr.md#mesures-de-securite)
 
-__Vues de l'écosystème__
+#### Les points de terminaison de l'écosystème
 
 - [/api/entities](./model.fr.md#entites)
 - [/api/relations](./model.fr.md#relations)
 
-__Vue métier du système d'information__
+#### Les points de terminaison du métier du système d'information
 
 - [/api/macro-processuses](./model.fr.md#macro-processus)
 - [/api/processes](./model.fr.md#processus)
@@ -45,7 +45,7 @@ __Vue métier du système d'information__
 - [/api/actors](./model.fr.md#acteurs)
 - [/api/information](./model.fr.md#information)
 
-__Vue des applications__
+#### Les points de terminaison des applications
 
 - [/api/application-blocks](./model.fr.md#blocs-applicatif)
 - [/api/applications](./model.fr.md#applications)
@@ -54,7 +54,7 @@ __Vue des applications__
 - [/api/databases](./model.fr.md#bases-de-donnees)
 - [/api/fluxes](./model.fr.md#flux)
 
-__Vue de l'administration__
+#### Les points de terminaison de l'administration
 
 - [/api/zone-admins](./model.fr.md#zones-dadministration)
 - [/api/annuaires](./model.fr.md#services-dannuaire-dadministration)
@@ -62,7 +62,7 @@ __Vue de l'administration__
 - [/api/domaine-ads](./model.fr.md#domaines-active-directory-ldap)
 - [/api/admin-users](./model.fr.md#utilisateurs)
 
-__Vue de l'infrastructure logique__
+#### Les points de terminaison de l'infrastructure logique
 
 - [/api/networks](./model.fr.md#reseaux)
 - [/api/subnetworks](./model.fr.md#sous-reseaux)
@@ -80,7 +80,7 @@ __Vue de l'infrastructure logique__
 - [/api/certificates](./model.fr.md#certificats)
 - [/api/vlans](./model.fr.md#vlans)
 
-__Vue de l'infrastructure physique__
+#### Les points de terminaison de l'infrastructure physique
 
 - [/api/sites](./model.fr.md#sites)
 - [/api/buildings](./model.fr.md#batiments-salles)
@@ -99,8 +99,37 @@ __Vue de l'infrastructure physique__
 - [/api/mans](./model.fr.md#mans)
 - [/api/lans](./model.fr.md#lans)
 
-__Rapport__
+#### Les points de terminaison de la Configuration
 
+- [/api/documents](./model.md#documents)
+
+La particularité de ce point de terminaison est qu'il permet d'ajouter ou de télécharger un document.
+La syntaxe est la suivante:
+##### Exemple d'ajout d'un document dans mercator:
+```bash
+RESPONSE=$(http_call -X POST "$API/api/documents" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/json" \
+    -F "file=@./rapport.pdf")
+
+# Affichage JSON propre (jq décode, mais n'est plus dans $() )
+echo "$RESPONSE" | jq .
+
+DOC_ID=$(echo "$RESPONSE" | jq -r '.id // empty' 2>/dev/null)
+```
+
+##### Exemple de téléchargement d'un document de mercator:
+```bash
+ OUTFILE="./downloaded_${DOC_ID}.pdf"
+    curl -s -X GET "$API/api/documents/$DOC_ID/download" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Accept: application/octet-stream" \
+        -o "$OUTFILE" \
+        -w "HTTP %{http_code}\n"
+```
+
+
+#### Les rapports
 - /api/report/cartography
 - /api/report/entities
 - /api/report/applicationsByBlocks

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,17 +23,17 @@ php artisan passport:install
 For each object in the cartography data model, there is an API.
 The list of APIs can be found in /route/api.php
 
-__GDPR view__
+#### Endpoints for GDPR
 
 - [/api/data-processings](./model.md#register)
 - [/api/security-controls](./model.md#security-measures)
 
-__Ecosystem view__
+#### Endpoints for Ecosystem
 
 - [/api/entities](./model.md#entities)
 - [/api/relations](./model.md#relationships)
 
-__Information system business view__
+#### Endpoints for Information system business
 
 - [/api/macro-processuses](./model.md#macro-processes)
 - [/api/processes](./model.md#processes)
@@ -43,7 +43,7 @@ __Information system business view__
 - [/api/actors](./model.md#actors)
 - [/api/information](./model.md#information)
 
-__Application view__
+#### Endpoints for Application
 
 - [/api/application-blocks](./model.md#applications-blocks)
 - [/api/applications](./model.md#applications)
@@ -52,7 +52,7 @@ __Application view__
 - [/api/databases](./model.md#databases)
 - [/api/fluxes](./model.md#flows)
 
-__Administration view__
+#### Endpoints for Administration view
 
 - [/api/zone-admins](./model.md#administration-areas)
 - [/api/annuaires](./model.md#administration-directory-services)
@@ -60,7 +60,7 @@ __Administration view__
 - [/api/domaine-ads](./model.md#active-directory-domains-ldap)
 - [/api/admin-users](./model.md#users)
 
-__Logical infrastructure view__
+#### Endpoints for Logical infrastructure
 
 - [/api/networks](./model.md#networks)
 - [/api/subnetworks](./model.md#subnetworks)
@@ -78,7 +78,7 @@ __Logical infrastructure view__
 - [/api/certificates](./model.md#certificates)
 - [/api/vlans](./model.md#vlans)
 
-__Physical infrastructure view__
+#### Endpoints for Physical infrastructure
 
 - [/api/sites](./model.md#sites)
 - [/api/buildings](./model.md#buildings-rooms)
@@ -97,7 +97,35 @@ __Physical infrastructure view__
 - [/api/lans](./model.md#lans)
 - [/api/physical-links](./model.md#physical-links)
 
-__Reports__
+#### Endpoints for Configuration
+- [/api/documents](./model.md#documents)
+
+The unique feature of this endpoint is that it allows you to either upload or download a document.
+The syntax is as follows:
+##### Example of adding a document in Mercator:
+```bash
+RESPONSE=$(http_call -X POST "$API/api/documents" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/json" \
+    -F "file=@./rapport.pdf")
+
+# Display clean JSON (jq uncode, but isn't yet in $() )
+echo "$RESPONSE" | jq .
+
+DOC_ID=$(echo "$RESPONSE" | jq -r '.id // empty' 2>/dev/null)
+```
+
+##### Exemple of downloading a document from mercator:
+```bash
+ OUTFILE="./downloaded_${DOC_ID}.pdf"
+    curl -s -X GET "$API/api/documents/$DOC_ID/download" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Accept: application/octet-stream" \
+        -o "$OUTFILE" \
+        -w "HTTP %{http_code}\n"
+```
+
+#### Endpoints for Reports
 
 - /api/report/cartography
 - /api/report/entities

--- a/docs/import.fr.md
+++ b/docs/import.fr.md
@@ -2,12 +2,11 @@
 
 🇬🇧 [Read in English](/mercator/import)
 
-Cette interface permet d’**importer** et d’**exporter** des données de la cartographie du système d'information via des
-feuilles de calcul.
+Cette interface permet d’**importer** et d’**exporter** des données de la cartographie du système d'information via des feuilles de calcul.
 
 ### Accès à la page
 
-La page d'import / export des données est accessible via le menu "Configration" -> "Import".
+La page d'import / export des données est accessible via le menu "Configuration" -> "Import".
 
 [<img src="/mercator/fr/images/import.png" width="700">](images/import.fr.png)
 

--- a/docs/model.fr.md
+++ b/docs/model.fr.md
@@ -1849,3 +1849,42 @@ L'export du modèle de données référence les MAN et les WAN rattachés à un 
 Dans l'application, un LAN peut être rattaché à un MAN ou un WAN depuis les objets MAN et WAN.
 
 
+### Configuration
+
+Dans le menu configuration, on trouve la partie documents.
+
+#### documents
+
+Cette partie permet de voir les documents attachés, mais aussi les icônes personnalisées.
+
+| Table                                     | api          |
+|:------------------------------------------|:-------------|
+| <span style="color: blue;">*documents*</span> | `/api/documents` |
+
+| Champ       | Type         | Description                         |
+|:------------|:-------------|:------------------------------------|
+| id          | int unsigned | auto_increment                      |
+| filename    | varchar(255) | Nom du document avec son extension |
+| mimetype    | varchar(255) | Type du document. Rempli automatiquement |
+| size        | int unsigned | Remplie automatiquement             |
+| hash        | longtext     | Hash du docuemnt. Rempli automatiquement |
+| created_at  | timestamp    | Date de création                    |
+| updated_at  | timestamp    | Date de mise à jour                 |
+| deleted_at  | timestamp    | Date de suppression                 |
+
+- Le document est créé dans le répertoire docs référencé par son id
+- Le document n'est pas inséré dans la base de donnée.
+
+##### Exemple d'information d'un document pour une icône de firewall:
+```json
+    "id": 1,
+    "filename": "fw.png",
+    "mimetype": "image/png",
+    "size": 5295,
+    "hash": "71ffcf1b3cfdbf2c0920abbbfcc472ae92d05a355967b0faed88c97e5c4187b0",
+    "deleted_at": null,
+    "created_at": "2026-03-30T08:05:46.000000Z",
+    "updated_at": "2026-03-30T08:05:46.000000Z"
+```
+
+⚠️ A partir de l'interface utilsiateur, si un document d'icône personnalisé est créé, il peut être utilisé par la même un asset de même catégorie tant qu'il existe au moins un asset dans la catégorie.

--- a/docs/model.md
+++ b/docs/model.md
@@ -1847,3 +1847,42 @@ The data model export lists MANs and WANs linked to a LAN.
 In the app, a MAN can be linked to a LAN from a MAN object.  
 A WAN can be linked to a LAN from a WAN object.
 
+### Configuration
+
+Dans le menu configuration, on trouve la partie documents.
+
+#### documents
+
+Thsi part allow to see all attached documents, including specific image (icons)
+
+| Table                                     | api          |
+|:------------------------------------------|:-------------|
+| <span style="color: blue;">*documents*</span> | `/api/documents` |
+
+| Champ       | Type         | Description                         |
+|:------------|:-------------|:------------------------------------|
+| id          | int unsigned | auto_increment                      |
+| filename    | varchar(255) | file name including extension          |
+| mimetype    | varchar(255) | Type of document. filled automatically |
+| size        | int unsigned | filled automatically                   |
+| hash        | longtext     | Hash du docuemnt. filled automatically |
+| created_at  | timestamp    | Date of creation                    |
+| updated_at  | timestamp    | Date of update                      |
+| deleted_at  | timestamp    | Date of deletion                    |
+
+- The document is created in docs directory, referenced by its ID
+- The document is not inserted in the database.
+
+##### Exemple of a document fields for a specific image of firewall:
+```json
+    "id": 1,
+    "filename": "fw.png",
+    "mimetype": "image/png",
+    "size": 5295,
+    "hash": "71ffcf1b3cfdbf2c0920abbbfcc472ae92d05a355967b0faed88c97e5c4187b0",
+    "deleted_at": null,
+    "created_at": "2026-03-30T08:05:46.000000Z",
+    "updated_at": "2026-03-30T08:05:46.000000Z"
+```
+
+⚠️ From user interface of mercator, if a document of specific image (personnalized icon) is created, This icon might be used by another asset of the same category as soon as there is, a least, one asset in the category. 


### PR DESCRIPTION
Bonjour,
Mise à jour des docs fr et en pour documents

Merci de relire pour voir si ça convient. 
Je ne suis pas sur du type des champs.
+ correction une faute de type dans import.fr


Olivier