### PR TITLE
Documentation: proposition de theme mkdocs material

### DIFF
--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -1,0 +1,29 @@
+/* Limite la largeur du contenu principal 
+/* .wy-nav-content { */
+/*    max-width: 1200px; */  /* Ajuste selon ton besoin */
+/*    mmargin: 0 auto;  */    /* Centre le contenu */
+/* }
+
+/* Change la couleur inline en bleue */
+.md-typeset code {
+    color: #0066cc;
+}
+/*
+.img-600 {
+  width: 600px !important;
+}
+.img-300 {
+  width: 300px !important;
+  max-width: none !important;
+}
+*/
+/*
+body {
+  border: 5px solid red;
+}
+
+.img-test {
+  border: 5px solid green !important;
+}
+*/
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ docs_dir: docs
 # Project information
 site_name: Mercator
 site_description: Mapping the Information System !
+site_url: https://dbarzin.githubs.io/mercator/
 
 # Repository
 repo_url: https://github.com/dbarzin/mercator
@@ -11,10 +12,44 @@ edit_uri: edit/master/docs
 # Copyright
 copyright: Copyright <a href="https://www.gnu.org/licenses/licenses.en.html">GPL</a>.
 
-site_url: https://dbarzin.githubs.io/mercator/
-
 theme:
-  name: readthedocs
+  name: material
+  language: en
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - toc.integrate
+    - content.code.copy
+    - content.action.edit
+    - content.action.view
+    - palette.toggle
+  palette:
+    - scheme: default
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+extra_css:
+  - css/overrides.css
+
+extra:
+  generator: false
+  alternate:
+    - name: English
+      link: /
+      lang: en
+    - name: Français
+      link: /fr/
+      lang: fr
 
 plugins:
   - search
@@ -26,46 +61,23 @@ plugins:
           default: true
           name: English
           build: true
-          # nav_translations:
-          #   Introduction: "Introduction"
-          #   Mapping: "Mapping"
-          #   Maturity: "Maturity"
-          #   Application: "Application"
-          #   BPMN 2.0: "BPMN 2.0"
-          #   Reports: "Reports"
-          #   Use cases: "Use cases"
-          #   Data model: "Data model"
-          #   Exploration: "Exploration"
-          #   Administration: "Administration"
-          #   Configuration: "Configuration"
-          #   Import: "Import"
-          #   API: "API"
-          #   API advanced (filters): "API advanced (filters)"
-          #   References: "References"
         - locale: fr
           name: Français
           build: true
-          # nav_translations:
-          #   Introduction: "Introduction"
-          #   Mapping: "Cartographie"
-          #   Maturity: "Maturité"
-          #   Application: "Application"
-          #   BPMN 2.0: "BPMN 2.0"
-          #   Reports: "Rapports"
-          #   Use cases: "Cas d'usage"
-          #   Data model: "Modèle de données"
-          #   Exploration: "Exploration"
-          #   Administration: "Administration"
-          #   Configuration: "Configuration"
-          #   Import: "Import"
-          #   API: "API"
-          #   API advanced (filters): "API avancée (filtres)"
-          #   References: "Références"
+      reconfigure_material: true
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
 
 nav:
   - index.md
-  - cartography.md
   - application.md
+  - cartography.md
   - maturity.md
   - bpmn.md
   - reports.md
@@ -78,28 +90,4 @@ nav:
   - admin.md
   - config.md
   - references.md
-# nav:
-#   - Introduction: index.md
-#   - Mapping: cartography.md
-#   - Application: application.md
-#   - Maturity: maturity.md
-#   - BPMN 2.0: bpmn.md
-#   - Reports: reports.md
-#   - Use cases: usecases.md
-#   - Data model: model.md
-#   - Exploration: exploration.md
-#   - Administration: admin.md
-#   - Configuration: config.md
-#   - Import: import.md
-#   - API: api.md
-#   - API advanced (filters): apifilters.md
-#   - References: references.md
 
-extra:
-  alternate:
-    - name: English
-      link: /
-      lang: en
-    - name: Français
-      link: /fr/
-      lang: fr


### PR DESCRIPTION
Bonjour,

**A lire  avant tout merge svp**

🔥 Changement du mode readthedocs en material pour avoir : la propositon de langue et le mode clair/sombre
nécessite:
```bash
pip install mkdocs-material
pip install mkdocs-material-extensions
```
- Ajout dans mkdocs.yml
```text
extra:
  generator: false pour ne pas utiliser sitemap.xml
```

Mais: il reste des erreurs 404, qui sont sans conséquences. elles sont générées par le browser en cherchant dans chaque répertoire de page ( qui n'existent pas)  
`WARNING -  [07:43:43] "GET /mercator/cartography/sitemap.xml HTTP/1.1" code 404`

Et le warning du lancement, est une information par rapport à la prochaine version de mkdocs
```text
 │ ⚠ WARNING – MkDocs 2.0 is incompatible with Material for MkDocs
 │ 
 │   MkDocs 1.x is unmaintained. We recommend switching to Zensical, our
 │   new static site generator, as soon as possible. We're providing an
 │   analysis of the situation in this article:
 │   
 │   https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/
```
Remarques et actions
Ajout de 
`css/overrides.css`
Pour remettre les inline (\`texte inline\`) en couleur bleue ( au lieu de noir dans material et rouge dans readthedocs) 
On peut donc adapter la couleur. 

le mode `mkdocs serve` ne récupère pas la page index.fr quand on change de langue par le menu material. Ca fonctionne avec `mkdocs build`

Mais avec build les certaines images  ne fonctionnent plus.

Donc j'ai testé comme ceci et :
- Ca fonctionne en serve
- Ca permet le cliquable
- Ca permet de changer la taille
Donc standardisation des images :
FR: [<img src="/mercator/fr/images/image.png" style="width:600px;">](images/image.png)
et 
EN: [<img src="/mercator/images/image.png" style="width:600px;">](images/image.png)

Pour tester 
```bash
mkdocs build
cd site
mkdir mercator
mv * mercator/
python3 -m http.server

A vous de voir si vous prenez ou non:

Dark mode:
<img width="1306" height="765" alt="image" src="https://github.com/user-attachments/assets/3a88b8c1-7e2f-421d-b708-45b5a5d2fdf8" />

