### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/resources/js/DynamicSelect.js
+++ b/resources/js/DynamicSelect.js
@@ -6,6 +6,15 @@
  */
 export default class DynamicSelect {
 
+    _escapeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     constructor(element, options = {}) {
         let defaults = {
             placeholder: 'Select an option',
@@ -50,24 +59,24 @@ export default class DynamicSelect {
             let optionWidth = 100 / this.columns;
             let optionContent = '';
             if (this.data[i].html) {
-                optionContent = this.data[i].html;
+                optionContent = this._escapeHtml(this.data[i].html);
             } else {
                 optionContent = `
-                    ${this.data[i].img ? `<img src="${this.data[i].img}" alt="${this.data[i].text}" class="${this.data[i].imgWidth && this.data[i].imgHeight ? 'dynamic-size' : ''}" style="${this.data[i].imgWidth ? 'width:' + this.data[i].imgWidth + ';' : ''}${this.data[i].imgHeight ? 'height:' + this.data[i].imgHeight + ';' : ''}">` : ''}
-                    ${this.data[i].text ? '<span class="dynamic-select-option-text">' + this.data[i].text + '</span>' : ''}
+                    ${this.data[i].img ? `<img src="${this._escapeHtml(this.data[i].img)}" alt="${this._escapeHtml(this.data[i].text)}" class="${this.data[i].imgWidth && this.data[i].imgHeight ? 'dynamic-size' : ''}" style="${this.data[i].imgWidth ? 'width:' + this._escapeHtml(this.data[i].imgWidth) + ';' : ''}${this.data[i].imgHeight ? 'height:' + this._escapeHtml(this.data[i].imgHeight) + ';' : ''}">` : ''}
+                    ${this.data[i].text ? '<span class="dynamic-select-option-text">' + this._escapeHtml(this.data[i].text) + '</span>' : ''}
                 `;
             }
             optionsHTML += `
-                <div class="dynamic-select-option${this.data[i].value == this.selectedValue ? ' dynamic-select-selected' : ''}${this.data[i].text || this.data[i].html ? '' : ' dynamic-select-no-text'}" data-value="${this.data[i].value}" style="width:${optionWidth}%;${this.height ? 'height:' + this.height + ';' : ''}">
+                <div class="dynamic-select-option${this.data[i].value == this.selectedValue ? ' dynamic-select-selected' : ''}${this.data[i].text || this.data[i].html ? '' : ' dynamic-select-no-text'}" data-value="${this._escapeHtml(this.data[i].value)}" style="width:${optionWidth}%;${this.height ? 'height:' + this._escapeHtml(this.height) + ';' : ''}">
                     ${optionContent}
                 </div>
             `;
         }
         let template = `
-            <div class="dynamic-select ${this.name}"${this.selectElement.id ? ' id="' + this.selectElement.id + '"' : ''} style="${this.width ? 'width:' + this.width + ';' : ''}${this.height ? 'height:' + this.height + ';' : ''}">
-                <input type="hidden" name="${this.name}" value="${this.selectedValue}">
-                <div class="dynamic-select-header" style="${this.width ? 'width:' + this.width + ';' : ''}${this.height ? 'height:' + this.height + ';' : ''}"><span class="dynamic-select-header-placeholder">${this.placeholder}</span></div>
-                <div class="dynamic-select-options" style="${this.options.dropdownWidth ? 'width:' + this.options.dropdownWidth + ';' : ''}${this.options.dropdownHeight ? 'height:' + this.options.dropdownHeight + ';' : ''}">${optionsHTML}</div>
+            <div class="dynamic-select ${this._escapeHtml(this.name)}"${this.selectElement.id ? ' id="' + this._escapeHtml(this.selectElement.id) + '"' : ''} style="${this.width ? 'width:' + this._escapeHtml(this.width) + ';' : ''}${this.height ? 'height:' + this._escapeHtml(this.height) + ';' : ''}">
+                <input type="hidden" name="${this._escapeHtml(this.name)}" value="${this._escapeHtml(this.selectedValue)}">
+                <div class="dynamic-select-header" style="${this.width ? 'width:' + this._escapeHtml(this.width) + ';' : ''}${this.height ? 'height:' + this._escapeHtml(this.height) + ';' : ''}"><span class="dynamic-select-header-placeholder">${this._escapeHtml(this.placeholder)}</span></div>
+                <div class="dynamic-select-options" style="${this.options.dropdownWidth ? 'width:' + this._escapeHtml(this.options.dropdownWidth) + ';' : ''}${this.options.dropdownHeight ? 'height:' + this._escapeHtml(this.options.dropdownHeight) + ';' : ''}">${optionsHTML}</div>
             </div>
         `;
         let element = document.createElement('div');
@@ -80,12 +89,13 @@ export default class DynamicSelect {
             option.onclick = () => {
                 this.element.querySelectorAll('.dynamic-select-selected').forEach(selected => selected.classList.remove('dynamic-select-selected'));
                 option.classList.add('dynamic-select-selected');
-                this.element.querySelector('.dynamic-select-header').innerHTML = option.innerHTML;
+                const header = this.element.querySelector('.dynamic-select-header');
+                header.replaceChildren(...Array.from(option.childNodes).map(node => node.cloneNode(true)));
                 this.element.querySelector('input').value = option.getAttribute('data-value');
                 this.data.forEach(data => data.selected = false);
                 this.data.filter(data => data.value == option.getAttribute('data-value'))[0].selected = true;
                 this.element.querySelector('.dynamic-select-header').classList.remove('dynamic-select-header-active');
-                this.options.onChange(option.getAttribute('data-value'), option.querySelector('.dynamic-select-option-text') ? option.querySelector('.dynamic-select-option-text').innerHTML : '', option);
+                this.options.onChange(option.getAttribute('data-value'), option.querySelector('.dynamic-select-option-text') ? option.querySelector('.dynamic-select-option-text').textContent : '', option);
             };
         });
         this.element.querySelector('.dynamic-select-header').onclick = () => {


### PR DESCRIPTION
Potential fix for [https://github.com/dbarzin/mercator/security/code-scanning/24](https://github.com/dbarzin/mercator/security/code-scanning/24)

Best fix: stop assigning untrusted interpolated strings to `innerHTML`. Build the DOM via element creation APIs and use `textContent`/`setAttribute`, which prevents HTML re-interpretation for textual values.

Within `resources/js/DynamicSelect.js`, the minimal robust fix is:
1. Add a small HTML-escaping helper (for places still using template strings).
2. Escape all interpolated values used in the HTML template (`name`, `id`, `value`, `text`, image/style fields, placeholders, widths/heights, etc.).
3. When copying selected option content to header, avoid `innerHTML = option.innerHTML`; clone child nodes instead.
4. In callback text extraction, use `textContent` instead of `innerHTML`.

This addresses all listed variants because all tainted values reaching `template` are encoded before `innerHTML`, and DOM-to-HTML copy in `_eventHandlers` is also made safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced processing of dynamic content in select options, including option text, HTML content, images, and their associated attributes.
* Improved handling of component attributes such as element names, IDs, dimensions, placeholders, and inline style values.
* Refined the mechanism for updating and displaying selected options to ensure more consistent and reliable rendering across user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->