### PR TITLE
helm: chart 2026.04.23 (app 2026.04.23)

### DIFF
--- a/docs/_helm_chart/chart/Chart.yaml
+++ b/docs/_helm_chart/chart/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2026.04.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/docs/_helm_chart/index/index.yaml
+++ b/docs/_helm_chart/index/index.yaml
@@ -3,7 +3,33 @@ entries:
   mercator:
   - apiVersion: v2
     appVersion: 2026.04.23
-    created: "2026-04-23T17:01:41.603803085+02:00"
+    created: "2026-04-23T17:08:42.936198591+02:00"
+    dependencies:
+    - condition: redis.enabled
+      name: redis
+      repository: oci://registry-1.docker.io/bitnamicharts
+      version: 20.x.x
+    - condition: postgresql.enabled
+      name: postgresql
+      repository: oci://registry-1.docker.io/bitnamicharts
+      version: 16.x.x
+    description: Mercator is a powerful and versatile open-source web application
+      designed to facilitate the mapping of information systems, as outlined in the
+      Mapping The Information System Guide by ANSSI.
+    digest: 431c6b6ef1b38e2acdc404c31a0a99f67ff3571190c229ee7242bb8ba4d16f8f
+    home: https://github.com/dbarzin/mercator
+    icon: https://raw.githubusercontent.com/dbarzin/mercator/refs/heads/master/public/images/mercator.png
+    maintainers:
+    - name: Mercator
+      url: https://github.com/dbarzin/mercator/chart
+    name: mercator
+    type: application
+    urls:
+    - https://github.com/dbarzin/mercator/releases/download/mercator-2026.04.23/mercator-2026.04.23.tgz
+    version: 2026.04.23
+  - apiVersion: v2
+    appVersion: 2026.04.23
+    created: "2026-04-23T17:08:42.920431205+02:00"
     dependencies:
     - condition: redis.enabled
       name: redis
@@ -25,7 +51,7 @@ entries:
     name: mercator
     type: application
     urls:
-    - https://github.com/dbarzin/mercator/releases/download/mercator-2.1.2/mercator-2.1.2.tgz
+    - https://github.com/dbarzin/mercator/releases/download/mercator-2026.04.23/mercator-2.1.2.tgz
     version: 2.1.2
   - apiVersion: v2
     appVersion: 2025.06.30
@@ -107,7 +133,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-04-23T17:01:41.591718191+02:00"
+    created: "2026-04-23T17:08:42.907447441+02:00"
     dependencies:
     - condition: redis.enabled
       name: redis
@@ -126,6 +152,6 @@ entries:
     name: mercator
     type: application
     urls:
-    - https://github.com/dbarzin/mercator/releases/download/mercator-2.1.2/mercator-0.1.0.tgz
+    - https://github.com/dbarzin/mercator/releases/download/mercator-2026.04.23/mercator-0.1.0.tgz
     version: 0.1.0
-generated: "2026-04-23T17:01:41.580531081+02:00"
+generated: "2026-04-23T17:08:42.895389127+02:00"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 2026.04.23 with corresponding repository index updates and download URL changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->