### PR TITLE
DOC: mkdocs add toc de la page en cours a droite et corrections mineures

### DIFF
--- a/docs/model.fr.md
+++ b/docs/model.fr.md
@@ -244,7 +244,7 @@ celui-ci.
 | security_need_t    | int          | Traçabilité                         |
 | security_need_auth | int          | Authenticité                        |
 | macroprocess_id    | int unsigned | Référence vers le macro-processus   |
-| activities         | List int [,] | Liste d'id des activitées liées     |
+| activities         | List int [,] | Liste d'id des activités liées     |
 | entities           | List int [,] | Liste d'id des entitées liées       |
 | informations       | List int [,] | Liste d'id des informations liées   |
 | applications       | List int [,] | Liste d'id des applications liées   |
@@ -295,15 +295,15 @@ pas forcément à une structure organisationnelle de l’entreprise.
 | recovery_time_objective     | int signed   | RTO, Temps cible de rétablissement de l'activité |
 | maximum_tolerable_downtime  | int signed   | Durée Maximale Tolérable de perturbation (DMTP)  |
 | recovery_point_objective    | int signed   | RPO, Point temporel de restauration des données  |
-| maximum_tolerable_data_loss | int signed   | Perte de Données Maximale Admissble (PDMA)       |
+| maximum_tolerable_data_loss | int signed   | Perte de Données Maximale Admissible (PDMA)       |
 | drp                         | text         | Description du plan de reprise d'activité (PRA)  |
 | drp_link                    | varchar(255) | Lien (URL) vers le PRA                           |
 | created_at                  | timestamp    | Date de création                                 |
 | updated_at                  | timestamp    | Date de mise à jour                              |
 | deleted_at                  | timestamp    | Date de suppression                              |
 
-DMTP : Temps d'interruption maximale avant que les conséquences ne se soient critiques ou ne deviennent innaceptables.  
-PDMA : perte de données maximales avant des conséquences critiques ou innaceptables.
+DMTP : Temps d'interruption maximale avant que les conséquences ne se soient critiques ou ne deviennent inacceptables.  
+PDMA : perte de données maximales avant des conséquences critiques ou inacceptables.
 
 L'export du modèle de données référence les processus, opérations et applications rattachées à une activité.
 
@@ -349,7 +349,7 @@ Une opération est composée d’acteurs et de tâches.
 | process_id  | int unsigned | Référence vers le processus dont fait partie l'opération |
 | actors      | List int [,] | Liste d'id des acteurs liés                              |
 | tasks       | List int [,] | Liste d'id des taches liées                              |
-| activities  | List int [,] | Liste d'id des activitées liées                          |
+| activities  | List int [,] | Liste d'id des activités liées                          |
 | created_at  | timestamp    | Date de création                                         |
 | updated_at  | timestamp    | Date de mise à jour                                      |
 | deleted_at  | timestamp    | Date de suppression                                      |
@@ -529,12 +529,12 @@ a un serveur logique par serveur physique.
 | product              | varchar(255) | Produit d'un éditeur pour recherche CPE                             |
 | version              | varchar(255) | Version d'un produit pour recherche CPE                             |
 | patching_frequency   | int          | Fréquence des mises à jour en part. de sécurité                     |
-| entities             | List int [,] | Liste d'id de(s) entitée(s) liée(s)                                 |
-| processes            | List int [,] | Liste d'id de(s) proces(ses) lié(s)                                 |
+| entities             | List int [,] | Liste d'id de(s) entité(s) liée(s)                                 |
+| processes            | List int [,] | Liste d'id de(s) process(es) lié(s)                                 |
 | services             | List int [,] | Liste d'id de(s) service(s) lié(s)                                  |
 | databases            | List int [,] | Liste d'id de(s) database(s) liée(s)                                |
 | logical_servers      | List int [,] | Liste d'id de(s) serveur(s) logique(s) servant(s) cette application |
-| activities           | List int [,] | Liste d'id de(s) activitée(s) associée(s)                           |
+| activities           | List int [,] | Liste d'id de(s) activité(s) associée(s)                           |
 | containers           | List int [,] | Liste d'id de(s) containers associé(s)                              |
 | created_at           | timestamp    | Date de création                                                    |
 | updated_at           | timestamp    | Date de mise à jour                                                 |
@@ -583,7 +583,7 @@ Ce bouton est présent dans la vue du RGDP et visible dans la liste des objets M
 Dans l'application, un conteneur peut être rattaché à une application depuis ces deux objets.  
 Dans l'application, le champ *évènements majeurs* est géré dans une table à part.
 
-#### Evènements majeurs
+#### Évènements majeurs
 
 Les évènements majeurs sont les principaux évènements subis par une application au cours de son exploitation.  
 Les évènements majeurs ne sont accessibles qu'à travers les objets applications.
@@ -727,7 +727,7 @@ Par exemple, les requêtes DNS ou NTP ne devraient pas être représentées comm
 | <span style="color: purple;">*device***_dest_id   | int unsigned | Lien vers l'actif destinataire            |
 | crypted                                           | tinyint(1)   | Le flux est chiffré (1=oui, O=non)        |
 | bidirectional                                     | tinyint(1)   | Le flux est bidirectionnel (1=oui, O=non) |
-| nature                                            | varcahr(255) | Nature du flux applicatif                 |
+| nature                                            | varchar(255) | Nature du flux applicatif                 |
 | created_at                                        | timestamp    | Date de création                          |
 | updated_at                                        | timestamp    | Date de mise à jour                       |
 | deleted_at                                        | timestamp    | Date de suppression                       |
@@ -1051,7 +1051,7 @@ Les équipements de sécurité sont des composants permettant la supervision du 
 protection des équipements ou ayant une fonction de sécurisation du système d’information.
 
 Les équipements de sécurité sont des systèmes de détection d'intrusion (ou IDS : Intrusion Detection System), des
-systèmes de prévention d'intrusion (ou IPS : Intrustion Prevention System), des systèmes de surveillance des
+systèmes de prévention d'intrusion (ou IPS : Intrusion Prevention System), des systèmes de surveillance des
 équipements.
 
 | Table                                                | api                     |
@@ -1172,7 +1172,7 @@ est découpé en un seul serveur logique.
 | icon_id            | int unsigned | Référence vers une image spécifique               |
 | type               | varchar(255) | Type du serveur (appli, DB, etc.)                 |
 | active             | tinyint(1)   | Serveur actif (1) ou obsolète (0)                 |
-| attributes         | varchar(255) | Attributs (tages) du serveur                      |
+| attributes         | varchar(255) | Attributs (tags) du serveur                      |
 | description        | longtext     | Description du serveur                            |
 | operating_system   | varchar(255) | Système d'exploitation                            |
 | install_date       | date         | Date d'installation du serveur                    |
@@ -1191,8 +1191,8 @@ est découpé en un seul serveur logique.
 | databases          | List int [,] | Liste d'id de(s)  base(s) de données liée(s)      |
 | cluster_id         | List int [,] | Liste d'id de(s) lien(s) cluster(s)               |
 | physical_servers   | List int [,] | Liste d'id de(s) serveur(s) physiques(s) associés |
-| applications       | List int [,] | Liste d'id de(s) application(s) hebergée(s)       |
-| containers         | List int [,] | Liste d'id de(s) containers hebergé(s)            |
+| applications       | List int [,] | Liste d'id de(s) application(s) hébergés(s)       |
+| containers         | List int [,] | Liste d'id de(s) containers hébergés(s)            |
 | created_at         | timestamp    | Date de création                                  |
 | updated_at         | timestamp    | Date de mise à jour                               |
 | deleted_at         | timestamp    | Date de suppression                               |
@@ -1283,7 +1283,7 @@ sur des serveurs logiques internes ou externes (cloud).
 | id          | int unsigned | auto_increment                               |
 | name        | varchar(255) | Nom du conteneur                             |
 | description | longtext     | Description du conteneur                     |
-| type        | varchar(255) | Type du conteneur (docker, kubernetes, etc.) |
+| type        | varchar(255) | Type du conteneur (docker, Kubernetes, etc.) |
 | icon_id     | int unsigned | Référence vers une image spécifique          |
 | applications | List int [,] | Liste d'id de(s) application(s) liée(s) |
 | databases   | List int [,] | Liste d'id de(s) base(s) de données liée(s)         |
@@ -1497,11 +1497,11 @@ Les serveurs physiques sont des machines physiques exécutant un ensemble de ser
 | description      | longtext     | Description du serveur                               |
 | type             | varchar(255) | Type / modèle du serveur                             |
 | cpu              | varchar(255) | Processeur(s) du serveur                             |
-| memory           | varchar(255) | RAM / mémoive vive du serveur                        |
+| memory           | varchar(255) | RAM / mémoire vive du serveur                        |
 | disk             | varchar(255) | Stockage du serveur                                  | 
 | disk_used        | varchar(255) | Stockage utilisé du serveur                          |
 | configuration    | longtext     | Configuration du serveur                             |
-| operating_system | varchar(255) | Système d'exploitaion du serveur                     |
+| operating_system | varchar(255) | Système d’exploitation du serveur                     |
 | install_date     | datetime     | Date d'installation du serveur                       |
 | update_date      | datetime     | Date de mise à jour du serveur                       |
 | responsible      | varchar(255) | Responsable d'exploitation du serveur                |
@@ -1547,7 +1547,7 @@ Les postes de travail sont des machines physiques permettant à un utilisateur d
 | id                | int unsigned | auto_increment                                                  |
 | name              | varchar(255) | Nom du poste de travail                                         |
 | icon_id           | int unsigned | Référence vers une image spécifique                             |
-| status            | varchar(255) | Status du poste (cyle de vie, incident)                         |
+| status            | varchar(255) | Status du poste (cycle de vie, incident)                         |
 | description       | longtext     | Description du poste de travail                                 |
 | type              | varchar(255) | Type / modèle du poste de travail                               |
 | entity_id         | int unsigned | Référence vers l'entité utilisatrice du poste                   |
@@ -1558,9 +1558,9 @@ Les postes de travail sont des machines physiques permettant à un utilisateur d
 | model             | varchar(255) | Modèle du poste                                                 |
 | serial_number     | varchar(255) | Numéro de série                                                 |
 | cpu               | varchar(255) | Processeur(s) du poste                                          |
-| memory            | varchar(255) | RAM / mémoive vive du poste                                     |
+| memory            | varchar(255) | RAM / mémoire vive du poste                                     |
 | disk              | int signed   | Quantité de stockage interne du poste                           |
-| operating_system  | varchar(255) | Système d'exploitaion du poste                                  |
+| operating_system  | varchar(255) | Système d’exploitation du poste                                  |
 | network_id        | int unsigned | Référence vers le réseau d'appartenance du poste                |
 | address_ip        | varchar(255) | Adresse(s) IP du poste                                          |
 | mac_address       | varchar(255) | Adresse(s) MAC / physique(s) du poste                           |
@@ -1616,7 +1616,7 @@ réseau (NAS), réseau de stockage (SAN), disque dur…
 |:------------|:-------------|:--------------------------------------------|
 | id          | int unsigned | auto_increment                              |
 | name        | varchar(255) | Nom de l'infrastructure de stockage         |
-| type        | varchar(255) | Type de l'infractructure de stockage        |
+| type        | varchar(255) | Type de l’infrastructure de stockage        |
 | description | longtext     | Description de l'infrastructure de stockage |
 | vendor      | varchar(255) | Vendeur / éditeur pour recherche CPE        |
 | product     | varchar(255) | Produit d'un éditeur pour recherche CPE     |
@@ -1804,7 +1804,7 @@ Les équipements de sécurité physique sont des sondes de températures, des ca
 | site_id          | int unsigned | Référence vers le site                                         |
 | building_id      | int unsigned | Référence vers le building / salle                             |
 | bay_id           | int unsigned | Référence vers la baie                                         |
-| security_devices | List int [,] | Liste des id de(s) equipements de sécurité (logiques) associés |
+| security_devices | List int [,] | Liste des id de(s) équipements de sécurité (logiques) associés |
 | address_ip       | varchar(255) | Adresse(s) IP de l'équipement                                  |
 | created_at       | timestamp    | Date de création                                               |
 | updated_at       | timestamp    | Date de mise à jour                                            |
@@ -1941,7 +1941,7 @@ Cette partie permet de voir les documents attachés, mais aussi les icônes pers
 | filename   | varchar(255) | Nom du document avec son extension       |
 | mimetype   | varchar(255) | Type du document. Rempli automatiquement |
 | size       | int unsigned | Remplie automatiquement                  |
-| hash       | longtext     | Hash du docuemnt. Rempli automatiquement |
+| hash       | longtext     | Hash du document. Rempli automatiquement |
 | created_at | timestamp    | Date de création                         |
 | updated_at | timestamp    | Date de mise à jour                      |
 | deleted_at | timestamp    | Date de suppression                      |
@@ -1964,7 +1964,7 @@ Cette partie permet de voir les documents attachés, mais aussi les icônes pers
 
 ⚠️ A partir de l'interface utilisateur, si un document d'icône personnalisé est créé, il peut être utilisé par un asset de même catégorie tant qu'il existe au moins un asset dans la catégorie.
 
-#### utilisateurs
+### utilisateurs
 
 Cette partie permet de voir la liste des utilisateurs de mercator avec le lien sur leur rôle associé.
 
@@ -1989,7 +1989,7 @@ Cette partie permet de voir la liste des utilisateurs de mercator avec le lien s
 | updated_at        | timestamp        | Date de mise à jour                      |
 | deleted_at        | timestamp        | Date de suppression                      |
 
-#### Roles
+### Roles
 
 Cette partie permet de voir la liste des roles des users dans mercator.
 
@@ -2005,7 +2005,7 @@ Cette partie permet de voir la liste des roles des users dans mercator.
 | updated_at | timestamp        | Date de mise à jour  |
 | deleted_at | timestamp        | Date de suppression  |
 
-#### Permissions
+### Permissions
 
 Cette partie permet de voir la liste des permissions qui peuvent être affectées aux roles.
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -9,7 +9,7 @@ processes, applications, and information used by the information system.
 
 This view is used to fulfill the obligations set out in article 30 of the GDPR.
 
-## Register
+### Register
 
 The register of processing activities contains the information required by article 30.1 of the GDPR.
 
@@ -60,7 +60,7 @@ An information can be linked with a data processing from a data processing objec
 An application can be linked to a data processing from a data processing object.  
 A document can be linked to a data processing from a data processing object.
 
-## Security measures
+### Security measures
 
 This table identifies the security measures applied to processes and applications.
 
@@ -89,7 +89,7 @@ mapping.
 This view not only delimits the scope of the mapping, but also provides an overall view of the ecosystem without being
 limited to the individual study of each entity.
 
-## Entities
+### Entities
 
 Entities are a part of the organization (e.g.: subsidiary, department, etc.) or related to the information system to be
 mapped.
@@ -127,7 +127,7 @@ An application can be linked with an entity (as operations manager) from these t
 
 In the app, a database can be linked with an entity (as operations manager) from these two objects.
 
-## Relationships
+### Relationships
 
 Relationships represent a link between two entities or systems.
 
@@ -184,7 +184,7 @@ involved, independently of the technological choices made by the organization an
 The business view is essential, as it allows you to reposition technical elements in their business environment, and
 thus understand their context of use.
 
-## Macro-processes
+### Macro-processes
 
 Macro-processes represent sets of processes.
 
@@ -214,7 +214,7 @@ This default configuration can be changed in the menu Configuration > Parameters
 
 In the application, a process can be linked with a macro-process from these two objects.
 
-## Processes
+### Processes
 
 Processes are a set of activities designed to achieve a goal. The process produces value-added information (
 output) (in the form of deliverables) from information (input) produced by other processes.
@@ -273,7 +273,7 @@ A GDPR registry data processing can be linked with a process from a registry dat
 A security measure can be linked with an application from the "Assign security controls" button.  
 This button is in the GDPR view and visible in the list of Security controls objects.
 
-## Activities
+### Activities
 
 An activity is a step required to carry out a process. It corresponds to a speciﬁc know-how and not necessarily to an
 organizational structure of the company.
@@ -308,7 +308,7 @@ An application can be linked with an activity from these two objects.
 
 In the app, the "Impact Type" and "Severity" fields are managed in a separate table.
 
-### Impacts
+#### Impacts
 
 Impacts are the consequences of the occurrence of a risk during an activity.  
 Impacts are only accessible through "activities" objects.
@@ -335,7 +335,7 @@ Impacts are only accessible through "activities" objects.
 | created_at  | timestamp     | Date of creation                                         |
 | updated_at  | timestamp     | Date of update                                           |
 
-## Operations
+### Operations
 
 An operation is made up of actors and tasks.
 
@@ -362,7 +362,7 @@ In the app, an activity can be linked with an operation from these two objects.
 An actor can be linked to an operation from the object "operation".  
 A task can be linked to an operation from the object "operation".
 
-## Tasks
+### Tasks
 
 A task is an elementary activity performed by an organizational function and constituting an indivisible unit of work in
 the value-added chain of a process.
@@ -384,7 +384,7 @@ The data model export lists operations linked to a task.
 
 In the app, an operation can be linked to a task from the object "operation".
 
-## Actors
+### Actors
 
 An actor is a representative of a business role who performs operations, uses applications, and makes decisions within
 processes. This role can be carried by a person, a group of people, or an entity.
@@ -409,7 +409,7 @@ The data model export lists operations linked with an actor.
 
 In the app, an operation can be linked with an actor from the object "operation".
 
-## Information
+### Information
 
 Information is data processed by a computer.
 Information can be inherited from another information.
@@ -466,7 +466,7 @@ The application view is used to describe part of what is classically referred to
 
 This view describes the technological solutions that support business processes, mainly applications.
 
-## Applications blocks
+### Applications blocks
 
 An application block represents a set of applications.
 
@@ -489,7 +489,7 @@ applications, etc.
 
 In the app, an application can be linked to an application block from these two objects.
 
-## Applications
+### Applications
 
 An application is a coherent set of IT objects (executables, programs, data, etc.). It is a grouping of application
 services.
@@ -587,7 +587,7 @@ This button is present in the GDPR view and visible in the list of Security cont
 In the app, a container can be linked with an application from these two objects.  
 In the app, the *major events* field is managed in a separate table.
 
-### Major events
+#### Major events
 
 Major events are the main events undergone by an application during its operation.  
 Major events are only accessible through application objects.
@@ -607,7 +607,7 @@ They are neither importable nor exportable through the graphics tool.
 | created_at       | timestamp    | Date of creation                                               |
 | updated_at       | timestamp    | Date of update                                                 |
 
-## Applications services
+### Applications services
 
 An application service is a specific service provided to a user to perform specific tasks related to their role in the
 organisation.
@@ -639,7 +639,7 @@ There are two fields containing the same information in the data model export, *
 *applications*.  
 The connection with application objects is made through the *applications* field.
 
-## Application modules
+### Application modules
 
 An application module is a component of an application characterized by functional coherence and technological
 homogeneity.
@@ -663,7 +663,7 @@ The export of the data model lists application services linked with an applicati
 
 In the app, an application service can be linked to an application module from these two objects.
 
-## Databases
+### Databases
 
 A database is a set of structured and ordered information meant for computed processing.
 
@@ -707,7 +707,7 @@ In the app, an application can be linked with a database from these two objects.
 In the app, a logical server can be linked with a database from these two objects.  
 In the app, a container can be linked with a database from these two objects.
 
-## Application Flows {#flows}
+### Application Flows {#flows}
 
 An application flow is an exchange of information between a sender and a receiver (application, application service,
 application module, or database).
@@ -753,7 +753,7 @@ In the app, an information can be linked with an application flow from an applic
 
 [<img src="/mercator/images/administration.png" width="400">](images/administration.png)
 
-## Administration area
+### Administration area
 
 An administration zone is a set of resources (people, data, equipment) under the responsibility of one (or more)
 administrator(s).
@@ -773,7 +773,7 @@ An administration zone is made up of Active Directory (AD) directory services an
 | updated_at  | timestamp    | Date of update   |
 | deleted_at  | timestamp    | Date of deletion |
 
-## Administration directory services
+### Administration directory services
 
 An administration directory service is an application that collects data on a company's users or IT equipment, enabling
 them to be administered.
@@ -795,7 +795,7 @@ It can be an inventory tool used to manage changes or tickets, or a mapping tool
 | updated_at    | timestamp    | Date of update                   |
 | deleted_at    | timestamp    | Date of deletion                 |
 
-## Active Directory forests / LDAP tree structure
+### Active Directory forests / LDAP tree structure
 
 These objects represent an organized grouping of Active Directory domains or LDAP trees.
 
@@ -814,7 +814,7 @@ These objects represent an organized grouping of Active Directory domains or LDA
 | updated_at    | timestamp    | Date of update                                  |
 | deleted_at    | timestamp    | Date of deletion                                |
 
-## Active Directory domains / LDAP
+### Active Directory domains / LDAP
 
 Active Directory domains / LDAP are company IT directories. They contains user and computer accounts, contacts,
 objects rights, and a part of IT policies (e.g. Group Policy Object - GPO).
@@ -841,7 +841,7 @@ The data model esport lists AD forests / LDAP trees linked with an AD domain / L
 In the app, an AD forest / LDAP tree can be linked with an AD domain / LDAP from these two objects.  
 A logical server can be linked with an AD domain / LDAP from these two objects.
 
-## Users
+### Users
 
 Users are user accounts with privileged rights on IT systems.
 
@@ -879,7 +879,7 @@ The logical infrastructure view corresponds to the logical distribution of the n
 It illustrates the partitioning of networks and the logical links between them. It also lists the network equipment that
 handles the traffic.
 
-## Networks
+### Networks
 
 Networks are a set of logically interconnected devices that exchange information.
 
@@ -908,7 +908,7 @@ In the app, the field for the authenticity need ("security_need_auth") is hidden
 entities subject to the regulation (EU) 2022/2554 (DORA).  
 This default configuration can be changed in the menu Configuration > Parameters.
 
-## Subnetworks
+### Subnetworks
 
 Subnetworks are a logical subdivision of a larger network.
 
@@ -939,7 +939,7 @@ Subnetworks are a logical subdivision of a larger network.
 
 The field "connected_subnets_id" is a foreign key. However, this one doesn't seem to be used.
 
-## External input gateways
+### External input gateways
 
 Gateways are components used to connect a local network to the outside world.
 
@@ -960,7 +960,7 @@ Gateways are components used to connect a local network to the outside world.
 
 In the application, a subnet can be linked with a gateway from these two objects.
 
-## Connected external entities
+### Connected external entities
 
 Connected external entities represent external entities connected to the network.
 
@@ -992,7 +992,7 @@ The data model export lists subnets and documents attached to a connected extern
 In the app, a subnet can be linked to a connected external entity from a connected external entity object.
 A document can be attached to a connected external entity from a connected external entity object.
 
-## Network switches
+### Network switches
 
 Network switches are the components that manage connections between the various servers on a network.
 
@@ -1015,7 +1015,7 @@ The data model export lists physical switches and VLANs linked with a network sw
 In the app, a VLAN can be linked with a network switch from these two objects.  
 A physical switch can be linked with a network switch from these two objects.
 
-## Logical routers
+### Logical routers
 
 Logical routers are logical components that manage connections between different networks.
 
@@ -1039,7 +1039,7 @@ The data model export lists physical routers linked to a logical router.
 
 In the app, a physical router can be linked to a logical router from these two objects.
 
-## Security devices {#security-devices}
+### Security devices {#security-devices}
 
 Security devices are components used for network supervision, incident detection, equipment protection, and information
 system security.
@@ -1074,13 +1074,13 @@ The data model export lists physical security device and applications linked to 
 In the app, physical security device can be linked to a logical security device from these two objects.  
 An application can be linked a to logical security device from these two objects.
 
-## DHCP servers
+### DHCP servers
 
 ```markdown
 ***NOTE***: The DHCP servers are kept for backward compatibility and to be compliant with ANSSI's guidelines.
 
 - ANSSI is the French cybersecurity regulation authority.
-  This object is considered barely usefull and obsolete. It's hidden by default.
+  This object is considered barely useful and obsolete. It's hidden by default.
 ```
 
 DHCP servers are physical or virtual devices that manage a network's IP addresses.
@@ -1094,18 +1094,18 @@ DHCP servers are physical or virtual devices that manage a network's IP addresse
 | id          | int unsigned | auto_increment                  |
 | name        | varchar(255) | Name of the DHCP server         |
 | description | longtext     | Description of the DHCP server  |
-| address_ip  | varchar(255) | IP addresse(s) IP of the server |
+| address_ip  | varchar(255) | IP address(es) IP of the server |
 | created_at  | timestamp    | Date of creation                |
 | updated_at  | timestamp    | Date of update                  |
 | deleted_at  | timestamp    | Date of deletion                |
 
-## DNS servers
+### DNS servers
 
 ```markdown
 ***NOTE***: The DNS servers are kept for backward compatibility and to be compliant with ANSSI's guidelines.
 
 - ANSSI is the French cybersecurity regulation authority.
-  This object is considered barely usefull and obsolete. It's hidden by default.
+  This object is considered barely useful and obsolete. It's hidden by default.
 ```
 
 Domain Name System (DNS) servers are physical or virtual devices that convert a domain name into an IP address.
@@ -1124,7 +1124,7 @@ Domain Name System (DNS) servers are physical or virtual devices that convert a 
 | updated_at  | timestamp    | Date of update                |
 | deleted_at  | timestamp    | Date of deletion              |
 
-## Clusters
+### Clusters
 
 Clusters are a set of logical servers hosted on one or more physical servers.
 
@@ -1151,7 +1151,7 @@ In the app, a logical router can be linked to a cluster from a cluster object.
 A logical server can be linked to a cluster from these two objects.  
 A physical server can be linked to a cluster from these two objects.
 
-## Logical servers
+### Logical servers
 
 Logical servers are a logical breakdown of a physical server. If the physical server is not virtualized, it is split
 into a single logical server.
@@ -1218,7 +1218,7 @@ A container can be linked with a logical server from a container object.
 The "documents" field doesn't appear to be used in a logical server's data model.
 
 
-## Backup Plans
+### Backup Plans
 
 Backup plans allow you to associate the **implemented backup strategies** with each **logical server**.  
 These strategies describe:  
@@ -1265,7 +1265,7 @@ This table serves as the reference for auditing backup compliance, identifying u
 | 6  | Mirror                    | 
 
 
-## Containers
+### Containers
 
 Containers are part of virtualization systems. They can operate in clusters or in isolation.
 on internal or external (cloud) logical servers.
@@ -1279,7 +1279,7 @@ on internal or external (cloud) logical servers.
 | id          | int unsigned | auto_increment                                  |
 | name        | varchar(255) | Container name                                  |
 | description | longtext     | Container description                           |
-| type        | varchar(255) | Type of the container (docker, kubernetes, ...) |
+| type        | varchar(255) | Type of the container (docker, Kubernetes, ...) |
 | icon_id     | int unsigned | Reference to a specific icon                    |
 | applications   | List int [,] | IDs list of related applications             |
 | databases      | List int [,] | IDs list of related database(s)              |
@@ -1288,13 +1288,13 @@ on internal or external (cloud) logical servers.
 | updated_at  | timestamp    | Date of update                                  |
 | deleted_at  | timestamp    | Date of deletion                                |
 
-The aata model export lists applications, databases, and logical servers linked with a container.
+The data model export lists applications, databases, and logical servers linked with a container.
 
 In the app, an application can be linked to a container from these two objects.  
 A database can be linked to a container from these two objects.  
 A logical server can be linked to a container from a container object.
 
-## Logical flows
+### Logical flows
 
 Logical flows describe relationships at layers 3 and 4 of the OSI model.
 
@@ -1341,7 +1341,7 @@ Source and destination devices can be:
 | clusters                 |   ✅    |      ✅      |
 | Subnetworks              |   ✅    |      ✅      |
 
-## Certificates
+### Certificates
 
 Electronic certificates are used to identify and authenticate services and individuals, as well as to encrypt exchanges.
 
@@ -1359,7 +1359,7 @@ Certificates are SSL keys, HTTPS certificates, etc. They are associated with log
 | type              | varchar(255) | Type of certificate (SSL, HTTPS ...) |
 | start_validity    | date         | Start date of validity               |
 | end_validity      | date         | End date of validity                 |
-| status            | int          | Certificate statis (RFC 6960)        |
+| status            | int          | Certificate status (RFC 6960)        |
 | logical_servers   | List int [,] | IDs list of related logical servers  |
 | applications      | List int [,] | IDs list of related applications     |
 | last_notification | datetime     | Last notification sent               |
@@ -1376,7 +1376,7 @@ The "last_notification" field is not used and therefore is absent in the app.
 
 The data model export lists applications and logical servers linked with a certificate.
 
-## VLANs
+### VLANs
 
 A VLAN (Virtual Local Area Network) or virtual LAN enables equipment to be logically grouped together, free from
 physical constraints.
@@ -1411,7 +1411,7 @@ The physical infrastructure view describes the physical equipment that makes up 
 
 This view corresponds to the geographical distribution of network equipment within the various sites.
 
-## Sites
+### Sites
 
 Sites are geographical locations that bring together a group of people and/or resources.
 
@@ -1431,7 +1431,7 @@ Sites are geographical locations that bring together a group of people and/or re
 
 In the app, a building / room can be linked with a site from a building / room objet.
 
-## Buildings / Rooms
+### Buildings / Rooms
 
 Buildings or rooms represent the location of people or resources within a site.
 
@@ -1456,7 +1456,7 @@ Buildings or rooms represent the location of people or resources within a site.
 In the app, a building / room or a site can be linked with a building / room from a building object /
 room.
 
-## Racks
+### Racks
 
 Racks are technical cabinets housing computer network or telephony equipment.
 
@@ -1476,7 +1476,7 @@ Racks are technical cabinets housing computer network or telephony equipment.
 
 In the app, a rack can be linked to a building / room from a rack objet.
 
-## Physical servers
+### Physical servers
 
 Physical servers are physical machines running a set of IT services.
 
@@ -1527,9 +1527,9 @@ have been gathered into the following table:
 | patching_group     | varchar(255) | Group for upgrade                   |
 | patching_frequency | varchar(255) | Frequency of upgrade                |
 | next_update        | date         | Date of next upgrade                |
-| physical_swicth_id | int unsigned | ID of related Physical switch       |
+| physical_switch_id | int unsigned | ID of related Physical switch       |
 
-## Workstations
+### Workstations
 
 Workstations are physical machines that enable a user to access the information system.
 
@@ -1588,11 +1588,11 @@ been gathered in the following table:
 | last_inventory_date | date         | Date of last inventory              |
 | update_source       | varchar(255) | Source of inventory update          |
 | agent_version       | varchar(255) | Inventory agent version             |
-| physical_swicth_id  | int unsigned | ID related to the physical switch   |
+| physical_switch_id  | int unsigned | ID related to the physical switch   |
 
 The "vendor", "product" and "version" fields are not used and therefore are absent of the app.
 
-## Storage infrastructures
+### Storage infrastructures
 
 ```markdown
 ***NOTE***: The storage infrastructures are kept for compatibility, but this table is not maintained anymore.
@@ -1628,7 +1628,7 @@ network (SAN), hard disk...
 
 The "vendor", "product" and "version" fields are not used and therefore are absent of the app.
 
-## Peripherals
+### Peripherals
 
 Peripherals are physical components connected to a workstation to add new functions (e.g. keyboard, mouse, printer,
 scanner, etc.).
@@ -1662,7 +1662,7 @@ The data model export lists applications using a peripheral.
 
 In the app, an application can be linked to a peripheral from a peripheral object.
 
-## Phones
+### Phones
 
 Landlines and mobile phones belonging to the organization.
 
@@ -1688,7 +1688,7 @@ The "vendor", "product" and "version" fields are not used and therefore are abse
 The filed "physical_switch_id" is not used and therefore is absent in the app. However, a phone object can be linked
 with a network switch (either physical or logical) through a physical link object.
 
-## Physical switches
+### Physical switches
 
 Physical switches are physical components that manage connections between different servers within a network.
 
@@ -1718,7 +1718,7 @@ The data model export lists logical network switches linked with a physical swit
 
 In the app, a physical switch can be linked with a logical network switch from these two objects.
 
-## Physical routers
+### Physical routers
 
 Physical routers are physical components that manage connections between different networks.
 
@@ -1752,7 +1752,7 @@ In the app, a physical router can be linked to a logical router (denoted as "Rou
 objects.  
 A VLAN can be linked to a physical router from a physical router object.
 
-## WiFi terminals
+### WiFi terminals
 
 WiFi hotspots are hardware devices that enable access to the WiFi wireless network.
 
@@ -1777,7 +1777,7 @@ WiFi hotspots are hardware devices that enable access to the WiFi wireless netwo
 | updated_at  | timestamp    | Date of update                      |
 | deleted_at  | timestamp    | Date of deletion                    |
 
-## Physical security device {#physical-security-devices}
+### Physical security device {#physical-security-devices}
 
 Physical security device includes components for network supervision, incident detection, equipment protection, and
 information system security.
@@ -1799,7 +1799,7 @@ Physical security device includes temperature sensors, cameras, security doors, 
 | building_id      | int unsigned | Reference to building / room                   |
 | bay_id           | int unsigned | Reference to rack                              |
 | security_devices | List int [,] | IDs list of related security devices (logical) |
-| address_ip       | varchar(255) | IP sddress                                     |
+| address_ip       | varchar(255) | IP address                                     |
 | created_at       | timestamp    | Date of creation                               |
 | updated_at       | timestamp    | Date of update                                 |
 | deleted_at       | timestamp    | Date of deletion                               |
@@ -1808,7 +1808,7 @@ The data model export lists logical security devices linked to a physical securi
 
 In the app, a logical security device can be linked to a physical security device from these two objects.
 
-## Physical links
+### Physical links
 
 Physical links represent the cables between physical or logical objects.  
 Logical objects can have physical links, for example within a virtualized network.  
@@ -1848,7 +1848,7 @@ Source and destination devices can be:
 | Logical switch           |   ✅    |      ✅      |
 | Logical router           |   ✅    |      ✅      |
 
-## WANs
+### WANs
 
 WANs (Wide Area Networks) are computer networks linking equipment over long distances. They generally interconnect MANs
 or LANs.
@@ -1872,7 +1872,7 @@ The data model export lists LANs and MANs linked to a WAN.
 In the app, a LAN can be linked to a WAN from a WAN object.  
 A MAN can be linked to a WAN from a WAN object.
 
-## MANs
+### MANs
 
 MANs (Middle Area Networks) are computer networks linking equipment over medium-sized distances. They generally
 interconnect LANs.
@@ -1895,7 +1895,7 @@ The data model export lists WANs and LANs linked to a MAN.
 In the app, a WAN can be linked to a MAN from a WAN object.  
 A LAN can be linked to a MAN from a MAN object.
 
-## LANs
+### LANs
 
 LANs (Local Area Networks) are computer networks linking equipment over a small geographical area.
 
@@ -1923,9 +1923,9 @@ A WAN can be linked to a LAN from a WAN object.
 
 Dans le menu configuration, on trouve la partie documents.
 
-## documents
+### documents
 
-Thsi part allow to see all attached documents, including specific image (icons)
+This part allow to see all attached documents, including specific image (icons)
 
 | Table                                         | api              |
 |:----------------------------------------------|:-----------------|
@@ -1937,7 +1937,7 @@ Thsi part allow to see all attached documents, including specific image (icons)
 | filename   | varchar(255) | file name including extension          |
 | mimetype   | varchar(255) | Type of document. filled automatically |
 | size       | int unsigned | filled automatically                   |
-| hash       | longtext     | Hash du docuemnt. filled automatically |
+| hash       | longtext     | Hash du document. filled automatically |
 | created_at | timestamp    | Date of creation                       |
 | updated_at | timestamp    | Date of update                         |
 | deleted_at | timestamp    | Date of deletion                       |
@@ -1958,9 +1958,9 @@ Thsi part allow to see all attached documents, including specific image (icons)
 "updated_at": "2026-03-30T08:05:46.000000Z"
 ```
 
-⚠️ From user interface of mercator, if a document of specific image (personnalized icon) is created, This icon might be used by another asset of the same category as soon as there is, a least, one asset in the category. 
+⚠️ From user interface of mercator, if a document of specific image (personalized icon) is created, This icon might be used by another asset of the same category as soon as there is, a least, one asset in the category. 
 
-#### users
+### users
 
 This part allows to see the mercator users list and their associated link to roles.
 
@@ -1985,7 +1985,7 @@ This part allows to see the mercator users list and their associated link to rol
 | updated_at        | timestamp        | Date of update                         |
 | deleted_at        | timestamp        | Date of deletion                       |
 
-#### Roles
+### Roles
 
 This part allows to see mercator roles list.
 
@@ -2001,7 +2001,7 @@ This part allows to see mercator roles list.
 | updated_at | timestamp        | Date of update       |
 | deleted_at | timestamp        | Date of deletion     |
 
-#### Permissions
+### Permissions
 
 This part allows to see all mercator permissions than can be allocated to roles.
 

--- a/docs/vulnerabilities.fr.md
+++ b/docs/vulnerabilities.fr.md
@@ -315,9 +315,6 @@ UNION ALL
 SELECT 'products', COUNT(*) FROM cpe_products
 UNION ALL
 SELECT 'versions', COUNT(*) FROM cpe_versions;
-
--- Date de la dernière synchronisation (approximation via updated_at)
-SELECT MAX(updated_at) AS derniere_maj FROM cpe_versions;
 ```
 
 Sous Docker :

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -313,9 +313,6 @@ UNION ALL
 SELECT 'products', COUNT(*) FROM cpe_products
 UNION ALL
 SELECT 'versions', COUNT(*) FROM cpe_versions;
-
--- Date of last synchronization (approximation via updated_at)
-SELECT MAX(updated_at) AS last_sync FROM cpe_versions;
 ```
 
 Under Docker:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ theme:
     - navigation.sections
     - navigation.expand
     - navigation.top
-    - toc.integrate
+    #- toc.integrate
     - content.code.copy
     - content.action.edit
     - content.action.view
@@ -64,7 +64,7 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
   - pymdownx.highlight
   - pymdownx.superfences
 


### PR DESCRIPTION
Bonjour,

Je propose d'ajouter la table des matières de la page en cours à droite, car pour la page model de données, c'est plus facile pour trouver son asset.

Je vous laisse tester et voir si ça vous convient..
Olivier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling and typography errors in French and English data model documentation
  * Improved documentation structure with refined heading hierarchy for better readability
  * Enhanced table-of-contents navigation depth configuration
  * Simplified CPE database verification examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->