### PR TITLE
fix: update mkdocs.yml URLs from dbarzin to sourcentis

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,10 +3,10 @@ docs_dir: docs
 # Project information
 site_name: Mercator
 site_description: Mapping the Information System !
-site_url: https://dbarzin.githubs.io/mercator/
+site_url: https://sourcentis.github.io/mercator/
 
 # Repository
-repo_url: https://github.com/dbarzin/mercator
+repo_url: https://github.com/sourcentis/mercator
 edit_uri: edit/master/docs
 
 # Copyright


### PR DESCRIPTION
Fix site_url (was also misspelled "githubs"), repo_url, and edit_uri to point to sourcentis/mercator after repository migration.