### PR TITLE
Fix/chart workflow upstream

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -35,12 +35,10 @@ jobs:
 
       - name: Commit Chart version and appVersion
         uses: EndBug/add-and-commit@v9
-        env:
-          CHART_APPVERSION: ${{ steps.version.outputs.version }}
         with:
-          default_author: github_actions
-          message: "chore: bump chart version to ${{ env.CHART_APPVERSION }}"
-          add: 'docs/_helm_chart/chart/Chart.yaml'
+          default_author: github_actions_bot
+          message: "chore: bump chart version to ${{ steps.version.outputs.version }}"
+          add: docs/_helm_chart/chart/Chart.yaml
 
       - name: Configure git identity
         run: |
@@ -53,9 +51,9 @@ jobs:
           charts_dir: docs/_helm_chart
           skip_existing: true
           mark_as_latest: false
-          pages_branch: master
+          pages_branch: gh-pages
         env:
-          CR_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Trigger docs deployment
         uses: actions/github-script@v7

--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -42,6 +42,11 @@ jobs:
           message: "chore: bump chart version to ${{ env.CHART_APPVERSION }}"
           add: 'docs/_helm_chart/chart/Chart.yaml'
 
+      - name: Configure git identity
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
@@ -49,7 +54,6 @@ jobs:
           skip_existing: true
           mark_as_latest: false
           pages_branch: master
-          pages_index_path: docs/_helm_chart/index/index.yaml
         env:
           CR_TOKEN: "${{secrets.GITHUB_TOKEN}}"
 


### PR DESCRIPTION
fix: correct chart-releaser workflow configuration
- Use github_actions_bot author preset (avoids empty git identity error)
- Reference version via steps output instead of broken env scope
- Change pages_branch from master to gh-pages (correct target for index)
- Fix CR_TOKEN spacing for consistency
- pages_index_path removed (line 56 in old file). Input did not exist in v1.7.0, silently ignored but was generated a  warning.
- Step "Configure git identity" added (line 45-48) just befor chart-releaser.