### PR TITLE
pass sensitive information to Secret Env

### DIFF
--- a/docs/_helm_chart/chart/templates/deployment.yaml
+++ b/docs/_helm_chart/chart/templates/deployment.yaml
@@ -102,8 +102,6 @@ spec:
               value: {{ .Values.smtp.port | quote }}
             - name: MAIL_USERNAME
               value: {{ .Values.smtp.username | quote }}
-            - name: MAIL_PASSWORD
-              value: {{ .Values.smtp.password | quote }}
             - name: MAIL_ENCRYPTION
               value: {{ .Values.smtp.encryption | quote }}
             - name: MAIL_FROM_ADDRESS
@@ -112,8 +110,6 @@ spec:
               value: {{ .Chart.Name | quote }}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.aws.access_key_id | quote }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.aws.secret_access_key | quote }}
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.aws.default_region | quote }}
             - name: AWS_BUCKET
@@ -122,8 +118,6 @@ spec:
               value: {{ .Values.pusher.app_id | quote }}
             - name: PUSHER_APP_KEY
               value: {{ .Values.pusher.app_key | quote }}
-            - name: PUSHER_APP_SECRET
-              value: {{ .Values.pusher.app_secret | quote }}
             - name: PUSHER_APP_CLUSTER
               value: {{ .Values.pusher.app_cluster | quote }}
             - name: MIX_PUSHER_APP_KEY
@@ -135,8 +129,6 @@ spec:
               value: "enabled"
             - name: KEYCLOAK_CLIENT_ID
               value: {{ .Values.keycloak.client_id | quote }}
-            - name: KEYCLOAK_CLIENT_SECRET
-              value: {{ .Values.keycloak.client_secret | quote }}
             - name: KEYCLOAK_REDIRECT_URI
               value: {{ .Values.keycloak.redirect_uri | quote }}
             - name: KEYCLOAK_BASE_URL
@@ -158,8 +150,6 @@ spec:
               value: {{ .Values.ldap.host | quote }}
             - name: LDAP_USERNAME
               value: {{ .Values.ldap.username | quote }}
-            - name: LDAP_PASSWORD
-              value: {{ .Values.ldap.password | quote }}
             - name: LDAP_PORT
               value: {{ .Values.ldap.service.number | quote }}
             - name: LDAP_BASE_DN
@@ -179,13 +169,13 @@ spec:
               value: {{ .Values.debug | quote }}
             - name: APP_ENV
               value: {{ .Values.environment | quote }}
-            - name: APP_KEY
-              value: {{ .Values.key | quote }}
             - name: APP_URL
               value: {{ .Values.reverse_proxy | quote }}
             - name: USE_DEMO_DATA
               value: {{ .Values.use_demo_data | quote }}
-
+          envFrom:
+            - secretRef:
+                name: {{ include "chart.fullname" . }}-secret-env
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/docs/_helm_chart/chart/templates/secretEnv.yaml
+++ b/docs/_helm_chart/chart/templates/secretEnv.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secretEnv.managed }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart.fullname" . }}-secret-env
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+type: Opaque
+data:
+  APP_KEY: {{- .Values.secretEnv.key | b64enc | quote }}
+  LDAP_PASSWORD: {{- .Values.secretEnv.ldap.password | b64enc | quote }}
+  KEYCLOAK_CLIENT_SECRET: {{- .Values.secretEnv.keycloak.client_secret | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{- .Values.secretEnv.aws.secret_access_key | b64enc | quote }}
+  PUSHER_APP_SECRET: {{- .Values.secretEnv.pusher.app_secret | b64enc | quote }}
+{{- end }}

--- a/docs/_helm_chart/chart/values.yaml
+++ b/docs/_helm_chart/chart/values.yaml
@@ -71,7 +71,6 @@ resources: {}
 
 debug: false
 environment: "development"
-key: ""
 reverse_proxy: "http://localhost"
 use_demo_data: 1
 seed_database: 1
@@ -83,7 +82,6 @@ ldap:
   connection: "default"
   host: "127.0.0.1"
   username: "cn=user,dc=local,dc=com"
-  password: "secret"
   base_dn: "dc=local,dc=com"
   timeout: "5"
   service:
@@ -97,26 +95,22 @@ smtp:
   host: "smtp.mailtrap.io"
   port: "25"
   username: ""
-  password: ""
   encryption: ""
   from_address: ""
 
 aws:
   access_key_id: ""
-  secret_access_key: ""
   default_region: "us-east-1"
   bucket: ""
 
 pusher:
   app_id: ""
   app_key: ""
-  app_secret: ""
   app_cluster: "mt1"
 
 keycloak:
   enabled: false
   client_id: ""       # Client Name (on Keycloak)
-  client_secret: ""   # Client Secret
   redirect_uri: ""    # <Mercator IP Address>/login/keycloak/callback
   base_url: ""        # <KeyCloak IP Address>
   realm: ""           # Realm Name
@@ -164,6 +158,20 @@ secret:
     postgresPassword: "2ù_-qeeYT21!8zA2~"
     password: "1ù_-qeeRH21!8zA1~"
 
+# Sensitive information passed as environment vars
+secretEnv:
+  managed: true
+  key: ""
+  smtp:
+    password: ""
+  ldap:
+    password: ""
+  keycloak:
+    client_secret: ""
+  aws:
+    secret_access_key: ""
+  pusher:
+    app_secret: ""
 
 postgresql:
   fullnameOverride: "postgresql"


### PR DESCRIPTION
Bonjour,

Voici une proposition d'évolution du chart helm afin que les données sensibles ne soient pas obligatoirement exposées dans le values.yaml mais dans un secret proposé par l'utilisateur (via un gestionnaire de Secrets). Les données sensibles sont déplacées dans le values.yaml et ensuite poussées sous forme de envFrom dans le Deployment.

Merci bien,

Philippe