### PR TITLE
quickfix: error 500 on logical server with soft-deleted domain

### DIFF
--- a/resources/views/admin/logicalServers/show.blade.php
+++ b/resources/views/admin/logicalServers/show.blade.php
@@ -108,7 +108,7 @@
                         <dt>{{ trans('cruds.logicalServer.fields.domain') }}</dt>
                     </th>
                     <td>
-                        @if ($logicalServer->domain_id!==null)
+                        @if ($logicalServer->domain!==null)
                             @canShow($logicalServer->domain)
                                 <a href="{{ route('admin.domains.show', $logicalServer->domain_id) }}">
                                     {{ $logicalServer->domain->name }}


### PR DESCRIPTION
When trying to consult a page of a logical server (`/admin/logical-servers/NN`) whose domain has been deleted, we get an error 500.

Sorry, I lack time to do a proper pull-request but there may be other cases : `git grep 'if.*->domain_id' resources/views/` so  anyone feel free to pick and rework it if I'm not back soon enough.